### PR TITLE
Versioning

### DIFF
--- a/client/albatross_client_bistro.ml
+++ b/client/albatross_client_bistro.ml
@@ -9,7 +9,7 @@ let read fd =
   let rec loop () =
     Vmm_tls_lwt.read_tls fd >>= function
     | Error `Eof ->
-      Logs.warn (fun m -> m "eof from server");
+      Logs.debug (fun m -> m "eof from server");
       Lwt.return (Ok ())
     | Error _ -> Lwt.return (Error (`Msg ("read failure")))
     | Ok wire ->

--- a/client/albatross_client_local.ml
+++ b/client/albatross_client_local.ml
@@ -2,8 +2,6 @@
 
 open Lwt.Infix
 
-let version = `AV4
-
 let socket t = function
   | Some x -> x
   | None -> Vmm_core.socket_path t
@@ -11,7 +9,7 @@ let socket t = function
 let process fd =
   Vmm_lwt.read_wire fd >|= function
   | Error _ -> Error ()
-  | Ok wire -> Ok (Albatross_cli.print_result version wire)
+  | Ok wire -> Ok (Albatross_cli.print_result wire)
 
 let read fd =
   (* now we busy read and process output *)
@@ -32,7 +30,7 @@ let handle opt_socket name (cmd : Vmm_commands.t) =
     in
     Lwt.return err
   | Some fd ->
-    let header = Vmm_commands.{ version ; sequence = 0L ; name } in
+    let header = Vmm_commands.header name in
     Vmm_lwt.write_wire fd (header, `Command cmd) >>= function
     | Error `Exception -> Lwt.return (Error (`Msg "exception"))
     | Ok () ->
@@ -248,7 +246,7 @@ let default_cmd =
     `P "$(tname) connects to albatrossd via a local socket" ]
   in
   Term.(ret (const help $ setup_log $ socket $ Term.man_format $ Term.choice_names $ Term.pure None)),
-  Term.info "albatross_client_local" ~version:"%%VERSION_NUM%%" ~doc ~man
+  Term.info "albatross_client_local" ~version ~doc ~man
 
 let cmds = [ help_cmd ; info_cmd ;
              policy_cmd ; remove_policy_cmd ; add_policy_cmd ;

--- a/client/albatross_client_remote_tls.ml
+++ b/client/albatross_client_remote_tls.ml
@@ -2,8 +2,6 @@
 
 open Lwt.Infix
 
-let version = `AV4
-
 let rec read_tls_write_cons t =
   Vmm_tls_lwt.read_tls t >>= function
   | Error `Eof ->
@@ -12,7 +10,7 @@ let rec read_tls_write_cons t =
   | Error _ ->
     Lwt.return (Error (`Msg ("read failure")))
   | Ok wire ->
-    Albatross_cli.print_result version wire ;
+    Albatross_cli.print_result wire ;
     read_tls_write_cons t
 
 let client cas host port cert priv_key =
@@ -82,7 +80,7 @@ let cmd =
     `P "$(tname) connects to an Albatross server and initiates a TLS handshake" ]
   in
   Term.(pure run_client $ setup_log $ cas $ client_cert $ client_key $ destination),
-  Term.info "albatross_client_remote_tls" ~version:"%%VERSION_NUM%%" ~doc ~man
+  Term.info "albatross_client_remote_tls" ~version ~doc ~man
 
 let () =
   match Term.eval cmd

--- a/command-line/albatross_cli.ml
+++ b/command-line/albatross_cli.ml
@@ -48,14 +48,12 @@ let init_influx name data =
     in
     Lwt.async report
 
-let print_result version (header, reply) =
-  if not (Vmm_commands.version_eq header.Vmm_commands.version version) then
-    Logs.err (fun m -> m "version not equal")
-  else match reply with
-    | `Success _ -> Logs.app (fun m -> m "%a" Vmm_commands.pp_wire (header, reply))
-    | `Data _ -> Logs.app (fun m -> m "%a" Vmm_commands.pp_wire (header, reply))
-    | `Failure _ -> Logs.warn (fun m -> m "%a" Vmm_commands.pp_wire (header, reply))
-    | `Command _ -> Logs.err (fun m -> m "unexpected command %a" Vmm_commands.pp_wire (header, reply))
+let print_result ((_, reply) as wire) =
+  match reply with
+  | `Success _ -> Logs.app (fun m -> m "%a" Vmm_commands.pp_wire wire)
+  | `Data _ -> Logs.app (fun m -> m "%a" Vmm_commands.pp_wire wire)
+  | `Failure _ -> Logs.warn (fun m -> m "%a" Vmm_commands.pp_wire wire)
+  | `Command _ -> Logs.err (fun m -> m "unexpected command %a" Vmm_commands.pp_wire wire)
 
 let setup_log style_renderer level =
   Fmt_tty.setup_std_outputs ?style_renderer ();
@@ -252,3 +250,7 @@ let count =
 let since_count since count = match since with
   | None -> `Count count
   | Some since -> `Since since
+
+let version =
+  Fmt.strf "version %%VERSION%% protocol version %a"
+    Vmm_commands.pp_version Vmm_commands.current

--- a/daemon/albatrossd.ml
+++ b/daemon/albatrossd.ml
@@ -177,7 +177,8 @@ let jump _ influx =
        in
 
        Lwt_list.iter_s (fun (name, config) ->
-           create stat_out log_out cons_out stub_data_out name config)
+           Lwt_mutex.with_lock create_lock (fun () ->
+               create stat_out log_out cons_out stub_data_out name config))
          (Vmm_trie.all old_unikernels) >>= fun () ->
 
        Lwt.catch (fun () ->

--- a/provision/albatross_provision.ml
+++ b/provision/albatross_provision.ml
@@ -1,6 +1,6 @@
 (* (c) 2017 Hannes Mehnert, all rights reserved *)
 
-let asn_version = `AV2
+let asn_version = `AV4
 
 let timestamps validity =
   let now = Ptime_clock.now () in

--- a/provision/albatross_provision.ml
+++ b/provision/albatross_provision.ml
@@ -1,7 +1,5 @@
 (* (c) 2017 Hannes Mehnert, all rights reserved *)
 
-let asn_version = `AV4
-
 let timestamps validity =
   let now = Ptime_clock.now () in
   match Ptime.add_span now (Ptime.Span.of_int_s (Duration.to_sec validity)) with

--- a/provision/albatross_provision_ca.ml
+++ b/provision/albatross_provision_ca.ml
@@ -45,10 +45,11 @@ let sign_csr dbname cacert key csr days =
        Ok ()
      else
        Error (`Msg "unknown version in request")) >>= fun () ->
-    let exts = match cmd with
-      | `Policy_cmd (`Policy_add _) -> d_exts ()
-      | _ -> l_exts
+    let exts, default_days = match cmd with
+      | `Policy_cmd (`Policy_add _) -> d_exts (), 365
+      | _ -> l_exts, 1
     in
+    let days = match days with None -> default_days | Some x -> x in
     Logs.app (fun m -> m "signing %a" Vmm_commands.pp cmd);
     (* the "false" is here since X509 validation bails on exts marked as
        critical (as required), but has no way to supply which extensions
@@ -121,7 +122,7 @@ let generate_cmd =
 
 let days =
   let doc = "Number of days" in
-  Arg.(value & opt int 1 & info [ "days" ] ~doc)
+  Arg.(value & opt (some int) None & info [ "days" ] ~doc)
 
 let cacert =
   let doc = "cacert" in

--- a/provision/albatross_provision_request.ml
+++ b/provision/albatross_provision_request.ml
@@ -5,11 +5,9 @@ open Vmm_asn
 
 open Rresult.R.Infix
 
-let version = `AV4
-
 let csr priv name cmd =
   let ext =
-    let v = cert_extension_to_cstruct (version, cmd) in
+    let v = to_cert_extension cmd in
     X509.Extension.(singleton (Unsupported oid) (false, v))
   and name =
     [ X509.Distinguished_name.(Relative_distinguished_name.singleton (CN name)) ]
@@ -199,7 +197,7 @@ let default_cmd =
     `P "$(tname) creates a certificate signing request for Albatross" ]
   in
   Term.(ret (const help $ setup_log $ Term.man_format $ Term.choice_names $ Term.pure None)),
-  Term.info "albatross_provision_request" ~version:"%%VERSION_NUM%%" ~doc ~man
+  Term.info "albatross_provision_request" ~version ~doc ~man
 
 let cmds = [ help_cmd ; info_cmd ;
              policy_cmd ; remove_policy_cmd ; add_policy_cmd ;

--- a/src/vmm_asn.ml
+++ b/src/vmm_asn.ml
@@ -455,12 +455,10 @@ let version =
   let f data = match data with
     | 4 -> `AV4
     | 3 -> `AV3
-    | 2 -> `AV2
     | x -> Asn.S.error (`Parse (Printf.sprintf "unknown version number 0x%X" x))
   and g = function
     | `AV4 -> 4
     | `AV3 -> 3
-    | `AV2 -> 2
   in
   Asn.S.map f g Asn.S.int
 
@@ -602,8 +600,7 @@ let log_disk_of_cstruct, log_disk_to_cstruct =
   let c = Asn.codec Asn.der log_disk in
   (Asn.decode c, Asn.encode c)
 
-let log_to_disk version entry =
-  log_disk_to_cstruct (version, entry)
+let log_to_disk entry = log_disk_to_cstruct (current, entry)
 
 let logs_of_disk buf =
   let rec next acc buf =
@@ -655,12 +652,11 @@ let unikernels =
 
 let unikernels_of_cstruct, unikernels_to_cstruct = projections_of unikernels
 
-type cert_extension = version * t
-
 let cert_extension =
   Asn.S.(sequence2
            (required ~label:"version" version)
            (required ~label:"command" wire_command))
 
-let cert_extension_of_cstruct, cert_extension_to_cstruct =
-  projections_of cert_extension
+let of_cert_extension, to_cert_extension =
+  let a, b = projections_of cert_extension in
+  a, (fun d -> b (current, d))

--- a/src/vmm_asn.mli
+++ b/src/vmm_asn.mli
@@ -17,14 +17,13 @@ val log_entry_to_cstruct : Log.t -> Cstruct.t
 
 val log_entry_of_cstruct : Cstruct.t -> (Log.t, [> `Msg of string ]) result
 
-val log_to_disk : Vmm_commands.version -> Log.t -> Cstruct.t
+val log_to_disk : Log.t -> Cstruct.t
 
 val logs_of_disk : Cstruct.t -> Log.t list
 
-type cert_extension = Vmm_commands.version * Vmm_commands.t
-
-val cert_extension_of_cstruct : Cstruct.t -> (cert_extension, [> `Msg of string ]) result
-val cert_extension_to_cstruct : cert_extension -> Cstruct.t
+val of_cert_extension :
+  Cstruct.t -> (Vmm_commands.version * Vmm_commands.t, [> `Msg of string ]) result
+val to_cert_extension : Vmm_commands.t -> Cstruct.t
 
 val unikernels_to_cstruct : Unikernel.config Vmm_trie.t -> Cstruct.t
 val unikernels_of_cstruct : Cstruct.t -> (Unikernel.config Vmm_trie.t, [> `Msg of string ]) result

--- a/src/vmm_commands.mli
+++ b/src/vmm_commands.mli
@@ -3,10 +3,12 @@
 open Vmm_core
 
 (** The type of versions of the grammar defined below. *)
-type version = [ `AV2 | `AV3 | `AV4 ]
+type version = [ `AV3 | `AV4 ]
 
-(** [version_eq a b] is true if [a] and [b] are equal. *)
-val version_eq : version -> version -> bool
+(** [current] is the current version. *)
+val current : version
+
+val is_current : version -> bool
 
 (** [pp_version ppf version] pretty prints [version] onto [ppf]. *)
 val pp_version : version Fmt.t
@@ -72,6 +74,8 @@ type header = {
   name : Name.t ;
 }
 
+val header : ?version:version -> ?sequence:int64 -> Name.t -> header
+
 type success = [
   | `Empty
   | `String of string
@@ -80,11 +84,14 @@ type success = [
   | `Block_devices of (Name.t * int * bool) list
 ]
 
-type wire = header * [
-    | `Command of t
-    | `Success of success
-    | `Failure of string
-    | `Data of data ]
+type res = [
+  | `Command of t
+  | `Success of success
+  | `Failure of string
+  | `Data of data
+]
+
+type wire = header * res
 
 val pp_wire : wire Fmt.t
 

--- a/src/vmm_vmmd.mli
+++ b/src/vmm_vmmd.mli
@@ -4,7 +4,7 @@ open Vmm_core
 
 type 'a t
 
-val init : Vmm_commands.version -> 'a t
+val init : unit -> 'a t
 
 val waiter : 'a t -> Name.t -> 'a t * 'a option
 
@@ -14,25 +14,23 @@ val register_restart : 'a t -> Name.t -> (unit -> 'b * 'a) -> ('a t * 'b) option
 
 type 'a create =
   Vmm_commands.wire *
-  ('a t -> ('a t * Vmm_commands.wire * Vmm_commands.wire * Vmm_commands.wire *
-            Name.t * Unikernel.t, [ `Msg of string ]) result) *
-  (unit -> Vmm_commands.wire)
+  ('a t -> ('a t * Vmm_commands.wire * Vmm_commands.wire * Vmm_commands.res * Name.t * Unikernel.t, [ `Msg of string ]) result) *
+  (unit -> Vmm_commands.res)
 
 val handle_shutdown : 'a t -> Name.t -> Unikernel.t ->
   [ `Exit of int | `Signal of int | `Stop of int ] -> 'a t * Vmm_commands.wire * Vmm_commands.wire
 
-val handle_create : 'a t -> Vmm_commands.header ->
-  Name.t -> Unikernel.config ->
+val handle_create : 'a t -> Name.t -> Unikernel.config ->
   ('a t * 'a create, [> `Msg of string ]) result
 
 val handle_command : 'a t -> Vmm_commands.wire ->
   ('a t *
-   [ `Create of Vmm_commands.header * Name.t * Unikernel.config
-   | `Loop of Vmm_commands.wire
-   | `End of Vmm_commands.wire
-   | `Wait of Name.t * (process_exit -> Vmm_commands.wire)
-   | `Wait_and_create of Name.t * (Vmm_commands.header * Name.t * Unikernel.config) ],
-   Vmm_commands.wire) result
+   [ `Create of Name.t * Unikernel.config
+   | `Loop of Vmm_commands.res
+   | `End of Vmm_commands.res
+   | `Wait of Name.t * (process_exit -> Vmm_commands.res)
+   | `Wait_and_create of Name.t * (Name.t * Unikernel.config) ],
+   Vmm_commands.res) result
 
 val killall : 'a t -> bool
 

--- a/stats/albatross_stat_client.ml
+++ b/stats/albatross_stat_client.ml
@@ -69,6 +69,6 @@ let vmname =
 
 let cmd =
   Term.(term_result (const jump $ setup_log $ pid $ vmname $ interval)),
-  Term.info "albatross_stat_client" ~version:"%%VERSION_NUM%%"
+  Term.info "albatross_stat_client" ~version
 
 let () = match Term.eval cmd with `Ok () -> exit 0 | _ -> exit 1

--- a/stats/albatross_stats.ml
+++ b/stats/albatross_stats.ml
@@ -40,7 +40,7 @@ let handle s addr =
         Vmm_lwt.write_wire s (fst wire, `Success (`String out)) >>= function
         | Ok () ->
           (match close with
-           | Some s' ->
+           | Some (_, s') ->
              Vmm_lwt.safe_close s' >>= fun () ->
              (* read the next *)
              loop ()
@@ -90,6 +90,6 @@ let interval =
 
 let cmd =
   Term.(term_result (const jump $ setup_log $ interval $ influx)),
-  Term.info "albatross_stats" ~version:"%%VERSION_NUM%%"
+  Term.info "albatross_stats" ~version
 
 let () = match Term.eval cmd with `Ok () -> exit 0 | _ -> exit 1

--- a/tls/albatross_tls_endpoint.ml
+++ b/tls/albatross_tls_endpoint.ml
@@ -30,9 +30,7 @@ let jump _ cacert cert priv_key port =
            Lwt.async (fun () ->
                Lwt.catch
                  (fun () ->
-                    (handle ca t >|= function
-                      | Error (`Msg msg) -> Logs.err (fun m -> m "error in handle %s" msg)
-                      | Ok () -> ()) >>= fun () ->
+                    handle ca t >>= fun () ->
                     Vmm_tls_lwt.close t)
                  (fun e ->
                     Logs.err (fun m -> m "error while handle() %s" (Printexc.to_string e)) ;
@@ -60,6 +58,6 @@ let port =
 
 let cmd =
   Term.(const jump $ setup_log $ cacert $ cert $ key $ port),
-  Term.info "albatross_tls_endpoint" ~version:"%%VERSION_NUM%%"
+  Term.info "albatross_tls_endpoint" ~version
 
 let () = match Term.eval cmd with `Ok () -> exit 0 | _ -> exit 1

--- a/tls/albatross_tls_inetd.ml
+++ b/tls/albatross_tls_inetd.ml
@@ -16,9 +16,7 @@ let jump cacert cert priv_key =
           Lwt.fail exn) >>= fun t ->
      Lwt.catch
        (fun () ->
-          (handle ca t >|= function
-            | Error (`Msg msg) -> Logs.err (fun m -> m "error in handle %s" msg)
-            | Ok () -> ()) >>= fun () ->
+          handle ca t >>= fun () ->
           Vmm_tls_lwt.close t)
        (fun e ->
           Logs.err (fun m -> m "error while handle() %s" (Printexc.to_string e)) ;
@@ -28,6 +26,6 @@ open Cmdliner
 
 let cmd =
   Term.(const jump $ cacert $ cert $ key),
-  Term.info "albatross_tls_inetd" ~version:"%%VERSION_NUM%%"
+  Term.info "albatross_tls_inetd" ~version:Albatross_cli.version
 
 let () = match Term.eval cmd with `Ok () -> exit 0 | _ -> exit 1

--- a/tls/vmm_tls.ml
+++ b/tls/vmm_tls.ml
@@ -11,7 +11,7 @@ let cert_name cert =
   | Some (_, data) ->
     match X509.(Distinguished_name.common_name (Certificate.subject cert)) with
     | Some name -> Ok (Some name)
-    | None -> match Vmm_asn.cert_extension_of_cstruct data with
+    | None -> match Vmm_asn.of_cert_extension data with
       | Error (`Msg _) -> Error (`Msg "couldn't parse albatross extension")
       | Ok (_, `Policy_cmd pc) ->
         begin match pc with
@@ -44,36 +44,33 @@ let separate_chain = function
   | [ leaf ] -> Ok (leaf, [])
   | leaf :: xs -> Ok (leaf, List.rev xs)
 
-let wire_command_of_cert version cert =
+let wire_command_of_cert cert =
   match Extension.(find (Unsupported Vmm_asn.oid) (Certificate.extensions cert)) with
   | None -> Error `Not_present
   | Some (_, data) ->
-    Vmm_asn.cert_extension_of_cstruct data >>= fun (v, wire) ->
-    if not (Vmm_commands.version_eq v version) then
-      Error (`Version v)
-    else
-      Ok wire
+    Vmm_asn.of_cert_extension data >>= fun (v, wire) ->
+    if not Vmm_commands.(is_current v) then
+      Logs.warn (fun m -> m "version mismatch, received %a current %a"
+                    Vmm_commands.pp_version v
+                    Vmm_commands.pp_version Vmm_commands.current);
+    Ok (v, wire)
 
-let extract_policies version chain =
+let extract_policies chain =
   List.fold_left (fun acc cert ->
-      match acc, wire_command_of_cert version cert with
+      match acc, wire_command_of_cert cert with
       | Error e, _ -> Error e
       | Ok acc, Error `Not_present -> Ok acc
       | Ok _, Error (`Msg msg) -> Error (`Msg msg)
-      | Ok _, Error (`Version received) ->
-        R.error_msgf "unexpected version %a (expected %a)"
-          Vmm_commands.pp_version received
-          Vmm_commands.pp_version version
-      | Ok (prefix, acc), Ok (`Policy_cmd (`Policy_add p)) ->
+      | Ok (prefix, acc), Ok (_, `Policy_cmd `Policy_add p) ->
         (cert_name cert >>= function
           | None -> Ok prefix
           | Some x -> Vmm_core.Name.prepend x prefix) >>| fun name ->
         (name, (name, p) :: acc)
       | _, Ok wire ->
-        R.error_msgf "unexpected wire %a" Vmm_commands.pp wire)
+        R.error_msgf "unexpected wire %a" Vmm_commands.pp (snd wire))
     (Ok (Vmm_core.Name.root, [])) chain
 
-let handle version chain =
+let handle chain =
   (if List.length chain < 10 then
      Ok ()
    else
@@ -90,22 +87,18 @@ let handle version chain =
   Logs.debug (fun m -> m "name is %a leaf is %a, chain %a"
                  Vmm_core.Name.pp name Certificate.pp leaf
                  Fmt.(list ~sep:(unit " -> ") Certificate.pp) rest);
-  extract_policies version rest >>= fun (_, policies) ->
+  extract_policies rest >>= fun (_, policies) ->
   (* TODO: logging let login_hdr, login_ev = Log.hdr name, `Login addr in *)
-  match wire_command_of_cert version leaf with
-  | Error (`Msg p) -> Error (`Msg p)
-  | Error (`Not_present) ->
+  match wire_command_of_cert leaf with
+  | Error `Msg p -> Error (`Msg p)
+  | Error `Not_present ->
     Error (`Msg "leaf certificate does not contain an albatross extension")
-  | Error (`Version received) ->
-    R.error_msgf "unexpected version %a (expected %a)"
-      Vmm_commands.pp_version received
-      Vmm_commands.pp_version version
-  | Ok wire ->
+  | Ok (v, wire) ->
     (* we only allow some commands via certificate *)
     match wire with
     | `Console_cmd (`Console_subscribe _)
     | `Stats_cmd `Stats_subscribe
     | `Log_cmd (`Log_subscribe _)
     | `Unikernel_cmd _
-    | `Policy_cmd `Policy_info -> Ok (name, policies, wire)
+    | `Policy_cmd `Policy_info -> Ok (name, policies, v, wire)
     | _ -> Error (`Msg "unexpected command")

--- a/tls/vmm_tls.ml
+++ b/tls/vmm_tls.ml
@@ -80,7 +80,7 @@ let handle chain =
   name rest >>= fun name' ->
   (* and subject common name of leaf certificate -- allowing dots in CN -- as postfix *)
   (cert_name leaf >>= function
-    | None -> Ok name'
+    | None | Some "." -> Ok name'
     | Some x ->
       Vmm_core.Name.of_string x >>| fun post ->
       Vmm_core.Name.concat name' post) >>= fun name ->

--- a/tls/vmm_tls.mli
+++ b/tls/vmm_tls.mli
@@ -1,10 +1,9 @@
 (* (c) 2018 Hannes Mehnert, all rights reserved *)
 
-val wire_command_of_cert : Vmm_commands.version -> X509.Certificate.t ->
-  (Vmm_commands.t, [> `Msg of string | `Not_present | `Version of Vmm_commands.version ]) result
+val wire_command_of_cert : X509.Certificate.t ->
+  (Vmm_commands.version * Vmm_commands.t, [> `Msg of string | `Not_present ]) result
 
 val handle :
-  Vmm_commands.version ->
   X509.Certificate.t list ->
-  (Vmm_core.Name.t * (Vmm_core.Name.t * Vmm_core.Policy.t) list * Vmm_commands.t,
-   [> `Msg of string ]) Result.result
+  (Vmm_core.Name.t * (Vmm_core.Name.t * Vmm_core.Policy.t) list * Vmm_commands.version * Vmm_commands.t,
+   [> `Msg of string ]) result


### PR DESCRIPTION
i think it is wiser to not embed version in each binary separately. and `--version` prints out the protocol version as well now!

also, provision_ca was buggy: it did just use the requested version, and not check anything. now, all to_cert_extension use the current(!) version.

daemons are reading a wire and reply with the same protocol version. on version mismatches a warning is printed (vmm_lwt / vmm_tls_lwt / vmm_provision). this means a best-effort supporting earlier albatross clients is now there! :)