### PR TITLE
stats: instead of executing the sysctl kinfo_proc twice (for retrieving kinfo_mem and rusage), only execute it once

### DIFF
--- a/stats/albatross_stat_client.ml
+++ b/stats/albatross_stat_client.ml
@@ -4,9 +4,8 @@ open Albatross_stats_pure
 let old_rt = ref 0L
 
 let timer pid vmmapi interval =
-  let rusage = sysctl_rusage pid in
+  let rusage, kinfo_mem = sysctl_kinfo_proc pid in
   Logs.app (fun m -> m "sysctl rusage: %a" Stats.pp_rusage_mem rusage) ;
-  let kinfo_mem = sysctl_kinfo_mem pid in
   Logs.app (fun m -> m "kinfo mem: %a" Stats.pp_kinfo_mem kinfo_mem) ;
   let delta, pct =
     if !old_rt = 0L then

--- a/stats/albatross_stats_stubs.c
+++ b/stats/albatross_stats_stubs.c
@@ -21,43 +21,9 @@
 #include <net/if_mib.h>
 #include <vmmapi.h>
 
-CAMLprim value vmmanage_sysctl_kinfo_mem (value pid_r) {
+CAMLprim value vmmanage_sysctl_kinfo_proc (value pid_r) {
   CAMLparam1(pid_r);
-  CAMLlocal2(res, start);
-  int name[4];
-  int error;
-  size_t len;
-  struct kinfo_proc p;
-
-  len = sizeof(p);
-  name[0] = CTL_KERN;
-  name[1] = KERN_PROC;
-  name[2] = KERN_PROC_PID;
-  name[3] = Int_val(pid_r);
-
-  error = sysctl(name, nitems(name), &p, &len, NULL, 0);
-  if (error < 0)
-    uerror("sysctl", Nothing);
-
-  res = caml_alloc(8, 0);
-  Store_field (res, 0, Val64(p.ki_size));
-  Store_field (res, 1, Val64(p.ki_rssize));
-  Store_field (res, 2, Val64(p.ki_tsize));
-  Store_field (res, 3, Val64(p.ki_dsize));
-  Store_field (res, 4, Val64(p.ki_ssize));
-  Store_field (res, 5, Val64(p.ki_runtime));
-  Store_field (res, 6, Val_int(p.ki_cow));
-  start = caml_alloc(2, 0);
-  Store_field (start, 0, Val64(p.ki_start.tv_sec));
-  Store_field (start, 1, Val_int(p.ki_start.tv_usec));
-  Store_field (res, 7, start);
-
-  CAMLreturn(res);
-}
-
-CAMLprim value vmmanage_sysctl_rusage (value pid_r) {
-  CAMLparam1(pid_r);
-  CAMLlocal3(res, utime, stime);
+  CAMLlocal4(res, res1, res2, time);
   int name[4];
   int error;
   size_t len;
@@ -72,36 +38,55 @@ CAMLprim value vmmanage_sysctl_rusage (value pid_r) {
 
   error = sysctl(name, nitems(name), &p, &len, NULL, 0);
   if (error < 0)
-    uerror("sysctl", Nothing);
+    uerror("sysctl ctl_kern.kern_proc.kern_proc_pid", Nothing);
+  if (p.ki_start.tv_usec < 0 || p.ki_start.tv_usec > 999999999)
+    uerror("sysctl ctl_kern.kern_proc.kern_proc_pid", Nothing);
+
+  res1 = caml_alloc(8, 0);
+  Store_field (res1, 0, Val64(p.ki_size));
+  Store_field (res1, 1, Val64(p.ki_rssize));
+  Store_field (res1, 2, Val64(p.ki_tsize));
+  Store_field (res1, 3, Val64(p.ki_dsize));
+  Store_field (res1, 4, Val64(p.ki_ssize));
+  Store_field (res1, 5, Val64(p.ki_runtime));
+  Store_field (res1, 6, Val_int(p.ki_cow));
+  time = caml_alloc(2, 0);
+  Store_field (time, 0, Val64(p.ki_start.tv_sec));
+  Store_field (time, 1, Val_int(p.ki_start.tv_usec));
+  Store_field (res1, 7, time);
 
   ru = p.ki_rusage;
   if (ru.ru_utime.tv_usec < 0 || ru.ru_utime.tv_usec > 999999999 ||
       ru.ru_stime.tv_usec < 0 || ru.ru_stime.tv_usec > 999999999)
-    uerror("sysctl", Nothing);
+    uerror("sysctl ctl_kern.kern_proc.kern_proc_pid", Nothing);
 
-  utime = caml_alloc(2, 0);
-  Store_field (utime, 0, Val64(ru.ru_utime.tv_sec));
-  Store_field (utime, 1, Val_int(ru.ru_utime.tv_usec));
-  stime = caml_alloc(2, 0);
-  Store_field (stime, 0, Val64(ru.ru_stime.tv_sec));
-  Store_field (stime, 1, Val_int(ru.ru_stime.tv_usec));
-  res = caml_alloc(16, 0);
-  Store_field (res, 0, utime);
-  Store_field (res, 1, stime);
-  Store_field (res, 2, Val64(ru.ru_maxrss));
-  Store_field (res, 3, Val64(ru.ru_ixrss));
-  Store_field (res, 4, Val64(ru.ru_idrss));
-  Store_field (res, 5, Val64(ru.ru_isrss));
-  Store_field (res, 6, Val64(ru.ru_minflt));
-  Store_field (res, 7, Val64(ru.ru_majflt));
-  Store_field (res, 8, Val64(ru.ru_nswap));
-  Store_field (res, 9, Val64(ru.ru_inblock));
-  Store_field (res, 10, Val64(ru.ru_oublock));
-  Store_field (res, 11, Val64(ru.ru_msgsnd));
-  Store_field (res, 12, Val64(ru.ru_msgrcv));
-  Store_field (res, 13, Val64(ru.ru_nsignals));
-  Store_field (res, 14, Val64(ru.ru_nvcsw));
-  Store_field (res, 15, Val64(ru.ru_nivcsw));
+  res2 = caml_alloc(16, 0);
+  time = caml_alloc(2, 0);
+  Store_field (time, 0, Val64(ru.ru_utime.tv_sec));
+  Store_field (time, 1, Val_int(ru.ru_utime.tv_usec));
+  Store_field (res2, 0, time);
+  time = caml_alloc(2, 0);
+  Store_field (time, 0, Val64(ru.ru_stime.tv_sec));
+  Store_field (time, 1, Val_int(ru.ru_stime.tv_usec));
+  Store_field (res2, 1, time);
+  Store_field (res2, 2, Val64(ru.ru_maxrss));
+  Store_field (res2, 3, Val64(ru.ru_ixrss));
+  Store_field (res2, 4, Val64(ru.ru_idrss));
+  Store_field (res2, 5, Val64(ru.ru_isrss));
+  Store_field (res2, 6, Val64(ru.ru_minflt));
+  Store_field (res2, 7, Val64(ru.ru_majflt));
+  Store_field (res2, 8, Val64(ru.ru_nswap));
+  Store_field (res2, 9, Val64(ru.ru_inblock));
+  Store_field (res2, 10, Val64(ru.ru_oublock));
+  Store_field (res2, 11, Val64(ru.ru_msgsnd));
+  Store_field (res2, 12, Val64(ru.ru_msgrcv));
+  Store_field (res2, 13, Val64(ru.ru_nsignals));
+  Store_field (res2, 14, Val64(ru.ru_nvcsw));
+  Store_field (res2, 15, Val64(ru.ru_nivcsw));
+
+  res = caml_alloc(2, 0);
+  Store_field (res, 1, res1);
+  Store_field (res, 0, res2);
 
   CAMLreturn(res);
 }
@@ -230,14 +215,9 @@ CAMLprim value vmmanage_sysctl_ifdata (value num) {
 
 /* stub symbols for OS currently not supported */
 
-CAMLprim value vmmanage_sysctl_rusage (value pid_r) {
+CAMLprim value vmmanage_sysctl_kinfo_proc (value pid_r) {
   CAMLparam1(pid_r);
-  uerror("sysctl_rusage", Nothing);
-}
-
-CAMLprim value vmmanage_sysctl_kinfo_mem (value pid_r) {
-  CAMLparam1(pid_r);
-  uerror("sysctl_kinfo_mem", Nothing);
+  uerror("sysctl_kinfo_proc", Nothing);
 }
 
 CAMLprim value vmmanage_sysctl_ifcount (value unit) {


### PR DESCRIPTION
this is fully backwards-compatible. I intended to integrate statistics for linux (reading `/proc/<pid>/stat`), and by looking at the available information, there'll be some incompatible changes. The main idea is to unify "rusage" and "kinfo_mem", and remove some of its elements (which haven't shown to be useful, or are not available on Linux).

I realise that on Linux the `/proc/<pid>/status` has more information (such as context switches), but is much harder to read and parse - still may be worth using that (but that doesn't contain the system/user time, neither startup time).

The main things of interest are:
- system time used
- user time used
- time since startup (i.e. uptime)
- virtual size (i.e. maximum amount of memory this process may use)
- current RSS (in pages (that's how it is available)) [maybe max rss as well]
- number of swaps
- page faults & reclaims
- block input/output (couldn't find this on Linux)