### PR TITLE
changes for linux deployment

### DIFF
--- a/packaging/Linux/albatross_console.service
+++ b/packaging/Linux/albatross_console.service
@@ -1,34 +1,21 @@
 [Unit]
-
 # To configure this service, please use the following command
 # to create an override configuration:
 # systemctl edit albatross_console.service
-
 Description=Albatross console daemon (albatross_console)
 After=syslog.target
+
 [Service]
 Type=simple
-
-#TODO no need to run as root!
-#Environment="albatross_console_user=root"
-User=root
-
-WorkingDirectory=/
-
-# TODO what does the following line do?
-Environment=albatross_prefix=/usr/local/sbin/albatross_console.exe
-#ExecStartPre=id # the fbsd scripts do something here, not sure what
-ExecStart=/usr/local/sbin/albatross_console.exe --tmpdir="%t/albatross/" -vv
-
-# state=%S
-# runtime=%t
-# small temp=%T
-# large temp=%V
-# PrivateTmp=yes
-
+User=albatross
+ExecStart=/usr/local/sbin/albatross-console --tmpdir="%t/albatross/" -vv
 RuntimeDirectoryPreserve=yes
-RuntimeDirectory=albatross albatross/fifo albatross/util
+RuntimeDirectory=albatross
+ExecStartPre=/bin/mkdir -p %t/albatross/fifo
+ExecStartPre=/bin/chmod 2770 %t/albatross/fifo
+ExecStartPre=/bin/mkdir -p %t/albatross/util
 PIDFile=%t/albatross/console.pid
+RestrictAddressFamilies=AF_UNIX
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/Linux/albatross_daemon.service
+++ b/packaging/Linux/albatross_daemon.service
@@ -1,37 +1,29 @@
 [Unit]
 Description=Albatross VMM daemon (albatrossd)
-Requires=albatross_console.service albatross_log.service albatross_stat.service
-After=syslog.target albatross_console.service albatross_log.service albatross_stat.service
+Requires=albatross_console.service albatross_log.service
+After=syslog.target albatross_console.service albatross_log.service
+
 [Service]
 Type=simple
-
 # TODO not necessarily needs to be run as root, anything that can solo5-spt/hvt,
 #  create tap interfaces should be fine!
-#Environment=albatross_daemon_user=root
-#User=${albatross_daemon_user}
 User=root
-
-WorkingDirectory=/
-
-#ExecStartPre=id # the fbsd scripts do something here, not sure what
-ExecStart=/usr/local/sbin/albatrossd.exe --tmpdir="%t/albatross/" -vv
-#--dbdir (defaults to /run/albatross)
-
-RuntimeDirectoryPreserve=yes
-RuntimeDirectory=albatross albatross/fifo albatross/util
-PIDFile=/%t/albatross/daemon.pid
+ExecStart=/usr/local/sbin/albatrossd --tmpdir="%t/albatross/" -vv
+#RuntimeDirectoryPreserve=yes
+#RuntimeDirectory=albatross
+PIDFile=%t/albatross/daemon.pid
 
 ## hardening stuff
 ProtectSystem=full
 ProtectHome=true
-UMask=0077
+#UMask=0077
 OOMScoreAdjust=-1000
 #AppArmorProfile=
 #SmackProcessLabel=albatross_vmm
 IgnoreSIGPIPE=true
 #SystemCallFilter=~reboot
 #SystemCallFilter=
-RestrictAddressFamilies=AF_UNIX AF_INET
+#RestrictAddressFamilies=AF_UNIX
 #RuntimeDirectoryMode=0700
 
 [Install]

--- a/packaging/Linux/albatross_log.service
+++ b/packaging/Linux/albatross_log.service
@@ -1,25 +1,19 @@
 [Unit]
-
 # To configure this service, please use the following command
 # to create an override configuration:
 # systemctl edit albatross_log.service
-
 Description=Albatross log daemon (albatross_log)
-After=syslog.target
+After=syslog.target albatross_console.service
+Requires=albatross_console.service
+
 [Service]
 Type=simple
-
-# TODO should not be root (needs to write to logfile (%L/albatross.log))
-User=root
-
-WorkingDirectory=/
-
-#ExecStartPre=id # the fbsd scripts do something here, not sure what
-ExecStart=/usr/local/sbin/albatross_log.exe --logfile="%L/albatross.log" --tmpdir="%t/albatross/" -vv
-
-RuntimeDirectory=albatross
-RuntimeDirectory=albatross albatross/fifo albatross/util
-PIDFile=/%t/albatross/log.pid
+User=albatross
+ExecStart=/usr/local/sbin/albatross-log --logfile="/var/lib/albatross/albatross.log" --tmpdir="%t/albatross/" -vv
+#RuntimeDirectory=albatross albatross/util
+#RuntimeDirectoryPreserve=yes # avoid albatross.log being cleaned up
+PIDFile=%t/albatross/log.pid
+RestrictAddressFamilies=AF_UNIX
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/Linux/albatross_stat.service
+++ b/packaging/Linux/albatross_stat.service
@@ -1,34 +1,18 @@
 [Unit]
-
 # To configure this service, please use the following command
 # to create an override configuration:
 # systemctl edit albatross_stat.service
-
 Description=Albatross stat daemon (albatross_stat)
 After=syslog.target
+
 [Service]
 Type=simple
-
-# TODO no need to run as root!
-#Environment="albatross_stat_user=root"
-User=root
-
-WorkingDirectory=/
-
-# TODO what does the following line do?
-Environment=albatross_prefix=/usr/local/sbin/albatross_stats.exe
-#ExecStartPre=id # the fbsd scripts do something here, not sure what
-ExecStart=/usr/local/sbin/albatross_stats.exe --tmpdir="%t/albatross/" -vv
-
-# state=%S
-# runtime=%t
-# small temp=%T
-# large temp=%V
-# PrivateTmp=yes
-
+User=albatross
+ExecStart=/usr/local/sbin/albatross-stats --tmpdir="%t/albatross/" -vv
 RuntimeDirectoryPreserve=yes
-RuntimeDirectory=albatross albatross/fifo albatross/util
+RuntimeDirectory=albatross albatross/util
 PIDFile=%t/albatross/stat.pid
+RestrictAddressFamilies=AF_UNIX
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/Linux/install.sh
+++ b/packaging/Linux/install.sh
@@ -1,18 +1,12 @@
 #!/bin/sh
 sudo mkdir -m 0700 -p /var/lib/albatross/block
 
-sudo cp ../../_build/default/client/*.exe /usr/local/sbin/
-sudo cp ../../_build/default/daemon/*.exe /usr/local/sbin/
-sudo cp ../../_build/default/provision/*.exe /usr/local/sbin/
-sudo cp ../../_build/default/stats/*.exe /usr/local/sbin/
-sudo cp ../../_build/default/tls/*.exe /usr/local/sbin/
-sudo cp ./albatross_*.service  /lib/systemd/system/
+sudo cp ../../_build/install/default/bin/* /usr/local/sbin/
+sudo cp ./albatross_*.service  /etc/systemd/system/
 sudo systemctl daemon-reload
-sudo systemctl stop   albatross_console
-sudo systemctl start  albatross_console
-sudo systemctl stop  albatross_log
+sudo systemctl stop albatross_console
+sudo systemctl start albatross_console
+sudo systemctl stop albatross_log
 sudo systemctl start albatross_log
-sudo systemctl stop  albatross_stat
-sudo systemctl start albatross_stat
-sudo systemctl stop  albatross_daemon
+sudo systemctl stop albatross_daemon
 sudo systemctl start albatross_daemon

--- a/src/vmm_unix.ml
+++ b/src/vmm_unix.ml
@@ -145,9 +145,9 @@ let create_tap bridge =
       | Ok _ -> find_n (succ x)
     in
     let tap = find_n 0 in
-    Bos.OS.Cmd.run Bos.Cmd.(v "ip" % "tuntap" % "add" % "mode" % "tap" % tap) >>= fun () ->
+    Bos.OS.Cmd.run Bos.Cmd.(v "ip" % "tuntap" % "add" % tap % "mode" % "tap") >>= fun () ->
     (* TODO maybe: ip link set $tap master $bridge -- no brctl *)
-    (* TODO also needed? ip link set dev $tap up -- or is it auto-up? *)
+    Bos.OS.Cmd.run Bos.Cmd.(v "ip" % "link" % "set" % "dev" % tap % "up") >>= fun () ->
     Bos.OS.Cmd.run Bos.Cmd.(v "brctl" % "addif" % bridge % tap) >>= fun () ->
     Ok tap
 


### PR DESCRIPTION
since I'm not too familiar with Linux and systemd, any review may be helpful. The main reason I started to change something was because it did not work, then all daemons were executed as superuser (not as intended). Then the permissions for `/run/albatross/fifo` were hard to get right (in the end, I use `ExecStartPre` which works -- in contrast to `RuntimeDirectoryMode` and multiple subdirectories in `RuntimeDirectory`). The `stat` service is useless for Linux at the moment anyways, so I disabled it (and the dependency onto it).

The other commit , to set the link to up, is necessary. Otherwise solo5 rejects the tap interface.