### PR TITLE
client: provide exit code depending on failure

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-12-0
+  image_family: freebsd-12-1
 
 freebsd_task:
   env:

--- a/client/dune
+++ b/client/dune
@@ -3,7 +3,7 @@
   (public_name albatross-client-bistro)
   (package albatross)
   (modules albatross_client_bistro)
-  (libraries albatross.cli albatross albatross.tls))
+  (libraries albatross.cli albatross albatross.tls albatross_tls_cli))
 
 (executable
   (name albatross_client_local)
@@ -17,4 +17,4 @@
   (public_name albatross-client-remote-tls)
   (package albatross)
   (modules albatross_client_remote_tls)
-  (libraries albatross.cli albatross albatross.tls))
+  (libraries albatross.cli albatross albatross.tls albatross_tls_cli))

--- a/tls/albatross_tls_common.ml
+++ b/tls/albatross_tls_common.ml
@@ -112,6 +112,25 @@ let handle ca tls =
       (Vmm_commands.header ~version name, reply) >|= fun _ ->
     ()
 
+let classify_tls_error = function
+  | Tls_lwt.Tls_alert
+      (Tls.Packet.BAD_CERTIFICATE
+      | Tls.Packet.UNSUPPORTED_CERTIFICATE
+      | Tls.Packet.CERTIFICATE_REVOKED
+      | Tls.Packet.CERTIFICATE_EXPIRED
+      | Tls.Packet.CERTIFICATE_UNKNOWN) as exn ->
+    Logs.err (fun m -> m "local authentication failure %s"
+                 (Printexc.to_string exn));
+    Albatross_cli.Local_authentication_failed
+  | Tls_lwt.Tls_failure (`Error (`AuthenticationFailure _)) as exn ->
+    Logs.err (fun m -> m "remove authentication failure %s"
+                 (Printexc.to_string exn));
+    Albatross_cli.Remote_authentication_failed
+  | exn ->
+    Logs.err (fun m -> m "failed to establish TLS connection: %s"
+                 (Printexc.to_string exn));
+    Albatross_cli.Communication_failed
+
 open Cmdliner
 
 let cacert =

--- a/tls/vmm_tls_lwt.ml
+++ b/tls/vmm_tls_lwt.ml
@@ -8,23 +8,15 @@ let read_tls t =
     if l = 0 then
       Lwt.return (Ok ())
     else
-      Lwt.catch (fun () ->
-          Tls_lwt.Unix.read t (Cstruct.shift buf off) >>= function
-          | 0 ->
-            Logs.debug (fun m -> m "TLS: end of file") ;
-            Lwt.return (Error `Eof)
-          | x when x == l -> Lwt.return (Ok ())
-          | x when x < l -> r_n buf (off + x) tot
-          | _ ->
-            Logs.err (fun m -> m "TLS: read too much, shouldn't happen") ;
-            Lwt.return (Error `Toomuch))
-        (function
-          | Tls_lwt.Tls_failure a ->
-            Logs.err (fun m -> m "TLS read failure: %s" (Tls.Engine.string_of_failure a)) ;
-            Lwt.return (Error `Exception)
-          | e ->
-            Logs.err (fun m -> m "TLS read exception %s" (Printexc.to_string e)) ;
-            Lwt.return (Error `Exception))
+      Tls_lwt.Unix.read t (Cstruct.shift buf off) >>= function
+      | 0 ->
+        Logs.debug (fun m -> m "TLS: end of file") ;
+        Lwt.return (Error `Eof)
+      | x when x == l -> Lwt.return (Ok ())
+      | x when x < l -> r_n buf (off + x) tot
+      | _ ->
+        Logs.err (fun m -> m "TLS: read too much, shouldn't happen") ;
+        Lwt.return (Error `Toomuch)
   in
   let buf = Cstruct.create 4 in
   r_n buf 0 4 >>= function


### PR DESCRIPTION
fixes #31, piggy-backs on the 'a in type 'a result = [ `Ok of 'a | ... ]
the code uses Ok Albatross_cli.Remote_command_failed to signal "exit 123"