### PR TITLE
Minor updates to albatrossd

### DIFF
--- a/command-line/albatross_cli.ml
+++ b/command-line/albatross_cli.ml
@@ -353,9 +353,13 @@ let exits =
     remote_command_failed ::
   Term.default_exits
 
-let disable_stats =
-  let doc = "Don't try to connect to albatross-stats to report statistics" in
-  Arg.(value & flag & info [ "disable-stats" ] ~doc)
+let enable_stats =
+  let doc = "Connect to albatross-stats to report statistics" in
+  Arg.(value & flag & info [ "enable-stats" ] ~doc)
+
+let retry_connections =
+  let doc = "Number of retries when connecting to other daemons (log, console, stats etc). 0 aborts after one failure, -1 is unlimited retries." in
+  Arg.(value & opt int 3 & info [ "retry-connections" ] ~doc)
 
 let auth_exits =
   [ Term.exit_info ~doc:"on local authentication failure \

--- a/command-line/albatross_cli.ml
+++ b/command-line/albatross_cli.ml
@@ -353,6 +353,10 @@ let exits =
     remote_command_failed ::
   Term.default_exits
 
+let disable_stats =
+  let doc = "Don't try to connect to albatross-stats to report statistics" in
+  Arg.(value & flag & info [ "disable-stats" ] ~doc)
+
 let auth_exits =
   [ Term.exit_info ~doc:"on local authentication failure \
                          (certificate not accepted by remote)"


### PR DESCRIPTION
Make `albatrossd` retry socket connections while waiting for log/console/stats daemons to start and return socket path in the error messages - this should allow the daemons to be started in any order. Also adds an explicit `--disable-stats`  option as it will now retry the socket connection indefinitely if this is not specified (perhaps this should be `--enable-stats` instead though).
