### PR TITLE
enhancements in tooling

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ freebsd_task:
     matrix:
       - OCAML_VERSION: 4.08.1
       - OCAML_VERSION: 4.09.0
-  pkg_install_script: pkg install -y ocaml-opam gmp gmake pkgconf
+  pkg_install_script: pkg install -y ocaml-opam gmp gmake pkgconf bash
   ocaml_script: opam init -a --comp=$OCAML_VERSION
   dependencies_script: eval `opam env` && opam install -y --deps-only .
   build_script: eval `opam env` && dune build

--- a/client/albatross_client_bistro.ml
+++ b/client/albatross_client_bistro.ml
@@ -115,6 +115,9 @@ let add_policy _ endp cert key ca name vms memory cpus block bridges =
 let info_ _ endp cert key ca name =
   jump endp cert key ca name (`Unikernel_cmd `Unikernel_info)
 
+let get _ endp cert key ca name =
+  jump endp cert key ca name (`Unikernel_cmd `Unikernel_get)
+
 let destroy _ endp cert key ca name =
   jump endp cert key ca name (`Unikernel_cmd `Unikernel_destroy)
 
@@ -196,6 +199,15 @@ let info_cmd =
   in
   Term.(const info_ $ setup_log $ destination $ ca_cert $ ca_key $ server_ca $ opt_vm_name),
   Term.info "info" ~doc ~man ~exits
+
+let get_cmd =
+  let doc = "retrieve a VM" in
+  let man =
+    [`S "DESCRIPTION";
+     `P "Downloads a VM."]
+  in
+  Term.(const get $ setup_log $ destination $ ca_cert $ ca_key $ server_ca $ vm_name),
+  Term.info "get" ~doc ~man ~exits
 
 let policy_cmd =
   let doc = "active policies" in
@@ -300,9 +312,9 @@ let default_cmd =
   Term.(ret (const help $ setup_log $ destination $ Term.man_format $ Term.choice_names $ Term.pure None)),
   Term.info "albatross_client_bistro" ~version ~doc ~man ~exits
 
-let cmds = [ help_cmd ; info_cmd ;
+let cmds = [ help_cmd ;
              policy_cmd ; remove_policy_cmd ; add_policy_cmd ;
-             destroy_cmd ; create_cmd ;
+             info_cmd ; get_cmd ; destroy_cmd ; create_cmd ;
              block_info_cmd ; block_create_cmd ; block_destroy_cmd ;
              console_cmd ; stats_cmd ; log_cmd ]
 

--- a/client/albatross_client_inspect_dump.ml
+++ b/client/albatross_client_inspect_dump.ml
@@ -1,0 +1,30 @@
+(* (c) 2020 Hannes Mehnert, all rights reserved *)
+
+let jump _ name dbdir =
+  Albatross_cli.set_dbdir dbdir;
+  match Vmm_unix.restore ?name () with
+  | Error `NoFile -> Error (`Msg "dump file not found")
+  | Error (`Msg msg) -> Error (`Msg ("while reading dump file: " ^ msg))
+  | Ok data -> match Vmm_asn.unikernels_of_cstruct data with
+    | Error (`Msg msg) -> Error (`Msg ("couldn't parse dump file: " ^ msg))
+    | Ok unikernels ->
+      let all = Vmm_trie.all unikernels in
+      Logs.app (fun m -> m "parsed %d unikernels:" (List.length all));
+      List.iter (fun (name, unik) ->
+          Logs.app (fun m -> m "%a: %a" Vmm_core.Name.pp name
+                       Vmm_core.Unikernel.pp_config unik))
+        all;
+      Ok ()
+
+open Cmdliner
+open Albatross_cli
+
+let file =
+  let doc = "File to read the dump from (prefixed by dbdir if relative)" in
+  Arg.(value & opt (some string) None & info [ "file" ] ~doc)
+
+let cmd =
+  Term.(term_result (const jump $ setup_log $ file $ dbdir)),
+  Term.info "albatross-client-inspect-dump" ~version
+
+let () = match Term.eval cmd with `Ok () -> exit 0 | _ -> exit 1

--- a/client/albatross_client_local.ml
+++ b/client/albatross_client_local.ml
@@ -57,6 +57,9 @@ let add_policy _ opt_socket name vms memory cpus block bridges =
 let info_ _ opt_socket name =
   jump opt_socket name (`Unikernel_cmd `Unikernel_info)
 
+let get _ opt_socket name =
+  jump opt_socket name (`Unikernel_cmd `Unikernel_get)
+
 let destroy _ opt_socket name =
   jump opt_socket name (`Unikernel_cmd `Unikernel_destroy)
 
@@ -130,6 +133,15 @@ let info_cmd =
   in
   Term.(term_result (const info_ $ setup_log $ socket $ opt_vm_name $ tmpdir)),
   Term.info "info" ~doc ~man ~exits
+
+let get_cmd =
+  let doc = "retrieve a VM" in
+  let man =
+    [`S "DESCRIPTION";
+     `P "Downloads a VM."]
+  in
+  Term.(term_result (const get $ setup_log $ socket $ vm_name $ tmpdir)),
+  Term.info "get" ~doc ~man ~exits
 
 let policy_cmd =
   let doc = "active policies" in
@@ -252,9 +264,9 @@ let default_cmd =
   Term.(ret (const help $ setup_log $ socket $ Term.man_format $ Term.choice_names $ Term.pure None)),
   Term.info "albatross_client_local" ~version ~doc ~man ~exits
 
-let cmds = [ help_cmd ; info_cmd ;
+let cmds = [ help_cmd ;
              policy_cmd ; remove_policy_cmd ; add_policy_cmd ;
-             destroy_cmd ; create_cmd ;
+             info_cmd ; get_cmd ; destroy_cmd ; create_cmd ;
              block_info_cmd ; block_create_cmd ; block_destroy_cmd ;
              console_cmd ;
              stats_subscribe_cmd ; stats_add_cmd ; stats_remove_cmd ; log_cmd ]

--- a/client/dune
+++ b/client/dune
@@ -17,4 +17,11 @@
   (public_name albatross-client-remote-tls)
   (package albatross)
   (modules albatross_client_remote_tls)
-  (libraries albatross.cli albatross albatross.tls albatross_tls_cli mirage-crypto-rng.lwt))
+  (libraries albatross.cli albatross albatross.tls albatross_tls_cli))
+
+(executable
+  (name albatross_client_inspect_dump)
+  (public_name albatross-client-inspect-dump)
+  (package albatross)
+  (modules albatross_client_inspect_dump)
+  (libraries albatross.cli albatross))

--- a/packaging/FreeBSD/create_package.sh
+++ b/packaging/FreeBSD/create_package.sh
@@ -42,7 +42,8 @@ install -U $bdir/stats/albatross_stat_client.exe $sbindir/albatross_stat_client
 
 for f in albatross_client_local \
              albatross_client_remote_tls \
-             albatross_client_bistro
+             albatross_client_bistro \
+             albatross_client_inspect_dump
 do install -U $bdir/client/$f.exe $sbindir/$f; done
 
 for f in albatross_provision_ca albatross_provision_request; do

--- a/provision/albatross_provision_request.ml
+++ b/provision/albatross_provision_request.ml
@@ -35,6 +35,8 @@ let add_policy _ name vms memory cpus block bridges =
 
 let info_ _ name = jump name (`Unikernel_cmd `Unikernel_info)
 
+let get _ name = jump name (`Unikernel_cmd `Unikernel_get)
+
 let destroy _ name =
   jump name (`Unikernel_cmd `Unikernel_destroy)
 
@@ -95,6 +97,15 @@ let info_cmd =
   in
   Term.(term_result (const info_ $ setup_log $ opt_vm_name)),
   Term.info "info" ~doc ~man
+
+let get_cmd =
+  let doc = "retrieve a VM" in
+  let man =
+    [`S "DESCRIPTION";
+     `P "Downloads a VM."]
+  in
+  Term.(term_result (const get $ setup_log $ vm_name)),
+  Term.info "get" ~doc ~man ~exits
 
 let policy_cmd =
   let doc = "active policies" in
@@ -199,9 +210,9 @@ let default_cmd =
   Term.(ret (const help $ setup_log $ Term.man_format $ Term.choice_names $ Term.pure None)),
   Term.info "albatross_provision_request" ~version ~doc ~man
 
-let cmds = [ help_cmd ; info_cmd ;
+let cmds = [ help_cmd ;
              policy_cmd ; remove_policy_cmd ; add_policy_cmd ;
-             destroy_cmd ; create_cmd ;
+             info_cmd ; get_cmd ; destroy_cmd ; create_cmd ;
              block_info_cmd ; block_create_cmd ; block_destroy_cmd ;
              console_cmd ; stats_cmd ; log_cmd ]
 

--- a/src/vmm_asn.ml
+++ b/src/vmm_asn.ml
@@ -356,13 +356,7 @@ let v0_unikernel_config =
     and fail_behaviour = `Quit (* TODO maybe set to restart by default :) *)
     in
     { typ ; compressed ; image ; fail_behaviour ; cpuid ; memory ; block_devices ; bridges ; argv }
-  and g vm =
-    let network_interfaces = match vm.bridges with [] -> None | xs -> Some (List.map fst xs)
-    and block_device = match vm.block_devices with [] -> None | x::_ -> Some x
-    and typ = if vm.compressed then `Hvt_amd64_compressed else `Hvt_amd64
-    in
-    let image = typ, vm.image in
-    (vm.cpuid, vm.memory, block_device, network_interfaces, image, vm.argv)
+  and g _vm = failwith "cannot encode v0 unikernel configs"
   in
   Asn.S.map f g @@
   Asn.S.(sequence6
@@ -383,11 +377,7 @@ let v1_unikernel_config =
     and block_devices = match blocks with None -> [] | Some xs -> xs
     in
     { typ ; compressed ; image ; fail_behaviour ; cpuid ; memory ; block_devices ; bridges ; argv }
-  and g vm =
-    let bridges = match vm.bridges with [] -> None | xs -> Some (List.map fst xs)
-    and blocks = match vm.block_devices with [] -> None | xs -> Some xs
-    in
-    (vm.typ, (vm.compressed, (vm.image, (vm.fail_behaviour, (vm.cpuid, (vm.memory, (blocks, (bridges, vm.argv))))))))
+  and g _vm = failwith "cannot encode v1 unikernel configs"
   in
   Asn.S.(map f g @@ sequence @@
            (required ~label:"typ" typ)

--- a/src/vmm_asn.ml
+++ b/src/vmm_asn.ml
@@ -280,7 +280,7 @@ let log_event =
                                    (sequence2
                                       (required ~label:"name" utf8_string)
                                       (required ~label:"device" utf8_string))))))
-              (explicit 7 null)))
+              (explicit 7 null (* placeholder *) )))
 
 
 let log_cmd =
@@ -420,26 +420,33 @@ let unikernel_config =
 
 let unikernel_cmd =
   let f = function
-    | `C1 () -> `Unikernel_info
-    | `C2 vm -> `Unikernel_create vm
-    | `C3 vm -> `Unikernel_force_create vm
-    | `C4 () -> `Unikernel_destroy
-    | `C5 vm -> `Unikernel_create vm
-    | `C6 vm -> `Unikernel_force_create vm
+    | `C1 `C1 () -> `Unikernel_info
+    | `C1 `C2 vm -> `Unikernel_create vm
+    | `C1 `C3 vm -> `Unikernel_force_create vm
+    | `C1 `C4 () -> `Unikernel_destroy
+    | `C1 `C5 vm -> `Unikernel_create vm
+    | `C1 `C6 vm -> `Unikernel_force_create vm
+    | `C2 `C1 () -> `Unikernel_get
+    | `C2 `C2 () -> assert false (* placeholder *)
   and g = function
-    | `Unikernel_info -> `C1 ()
-    | `Unikernel_create vm -> `C5 vm
-    | `Unikernel_force_create vm -> `C6 vm
-    | `Unikernel_destroy -> `C4 ()
+    | `Unikernel_info -> `C1 (`C1 ())
+    | `Unikernel_create vm -> `C1 (`C5 vm)
+    | `Unikernel_force_create vm -> `C1 (`C6 vm)
+    | `Unikernel_destroy -> `C1 (`C4 ())
+    | `Unikernel_get -> `C2 (`C1 ())
   in
   Asn.S.map f g @@
-  Asn.S.(choice6
-           (explicit 0 null)
-           (explicit 1 v1_unikernel_config)
-           (explicit 2 v1_unikernel_config)
-           (explicit 3 null)
-           (explicit 4 unikernel_config)
-           (explicit 5 unikernel_config))
+  Asn.S.(choice2
+          (choice6
+             (explicit 0 null)
+             (explicit 1 v1_unikernel_config)
+             (explicit 2 v1_unikernel_config)
+             (explicit 3 null)
+             (explicit 4 unikernel_config)
+             (explicit 5 unikernel_config))
+          (choice2
+             (explicit 6 null)
+             (explicit 7 null (* placeholder *) )))
 
 let policy_cmd =
   let f = function

--- a/src/vmm_commands.ml
+++ b/src/vmm_commands.ml
@@ -61,6 +61,7 @@ type unikernel_cmd = [
   | `Unikernel_create of Unikernel.config
   | `Unikernel_force_create of Unikernel.config
   | `Unikernel_destroy
+  | `Unikernel_get
 ]
 
 let pp_unikernel_cmd ppf = function
@@ -68,6 +69,7 @@ let pp_unikernel_cmd ppf = function
   | `Unikernel_create config -> Fmt.pf ppf "unikernel create %a" Unikernel.pp_config config
   | `Unikernel_force_create config -> Fmt.pf ppf "vm force create %a" Unikernel.pp_config config
   | `Unikernel_destroy -> Fmt.string ppf "unikernel destroy"
+  | `Unikernel_get -> Fmt.string ppf "unikernel get"
 
 type policy_cmd = [
   | `Policy_info

--- a/src/vmm_commands.mli
+++ b/src/vmm_commands.mli
@@ -35,6 +35,7 @@ type unikernel_cmd = [
   | `Unikernel_create of Unikernel.config
   | `Unikernel_force_create of Unikernel.config
   | `Unikernel_destroy
+  | `Unikernel_get
 ]
 
 type policy_cmd = [

--- a/src/vmm_unix.ml
+++ b/src/vmm_unix.ml
@@ -96,16 +96,22 @@ let close_no_err fd = try close fd with _ -> ()
 
 let dump, restore =
   let open R.Infix in
-  (fun data ->
-     let state_file = Fpath.(!dbdir / "state") in
+  let state_file ?(name = "state") () =
+    if Fpath.is_seg name then
+      Fpath.(!dbdir / name)
+    else
+      Fpath.v name
+  in
+  (fun ?name data ->
+     let state_file = state_file ?name () in
      Bos.OS.File.exists state_file >>= fun exists ->
      (if exists then begin
         let bak = Fpath.(state_file + "bak") in
         Bos.OS.U.(error_to_msg @@ rename state_file bak)
       end else Ok ()) >>= fun () ->
      Bos.OS.File.write state_file (Cstruct.to_string data)),
-  (fun () ->
-     let state_file = Fpath.(!dbdir / "state") in
+  (fun ?name () ->
+     let state_file = state_file ?name () in
      Bos.OS.File.exists state_file >>= fun exists ->
      if exists then
        Bos.OS.File.read state_file >>| fun data ->

--- a/src/vmm_unix.mli
+++ b/src/vmm_unix.mli
@@ -30,8 +30,8 @@ val destroy_block : Name.t -> (unit, [> R.msg ]) result
 
 val find_block_devices : unit -> ((Name.t * int) list, [> R.msg ]) result
 
-val dump : Cstruct.t -> (unit, [> R.msg ]) result
+val dump : ?name:string -> Cstruct.t -> (unit, [> R.msg ]) result
 
-val restore : unit -> (Cstruct.t, [> R.msg | `NoFile ]) result
+val restore : ?name:string -> unit -> (Cstruct.t, [> R.msg | `NoFile ]) result
 
 val vm_device : Unikernel.t -> (string, [> R.msg ]) result

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -236,6 +236,13 @@ let handle_unikernel_cmd t id = function
       | _ ->
         Ok (t, `End (`Success (`Unikernels vms)))
     end
+  | `Unikernel_get ->
+    Logs.debug (fun m -> m "get %a" Name.pp id) ;
+    begin match Vmm_trie.find id t.resources.Vmm_resources.unikernels with
+      | None -> Error (`Msg "get: no unikernel found")
+      | Some u ->
+        Ok (t, `End (`Success (`Unikernels [ (id, u.Unikernel.config) ])))
+    end
   | `Unikernel_create vm_config -> Ok (t, `Create (id, vm_config))
   | `Unikernel_force_create vm_config ->
     begin

--- a/tls/dune
+++ b/tls/dune
@@ -16,11 +16,11 @@
   (public_name albatross-tls-endpoint)
   (package albatross)
   (modules albatross_tls_endpoint)
-  (libraries albatross_cli albatross_tls_cli albatross mirage-crypto-rng.lwt))
+  (libraries albatross_cli albatross_tls_cli albatross))
 
 (executable
   (name albatross_tls_inetd)
   (public_name albatross-tls-inetd)
   (package albatross)
   (modules albatross_tls_inetd)
-  (libraries albatross_cli albatross_tls_cli albatross mirage-crypto-rng.lwt))
+  (libraries albatross_cli albatross_tls_cli albatross))


### PR DESCRIPTION
there is a new command line utility, `albatross-client-inspect-dump` which reads a state file written by albatross and outputs its content. This is mainly for debugging and upgrade purposes (executing this before upgrading albatross_daemon to ensure the dump file could be restored) - esp if data contents changes (I try to be careful, but this utility helps me to be even more careful) ;)

A `get` command which downloads a given running unikernel to the local filesystem and decompresses it. Thus, the exact binary can be locally inspected / executed / ...