### PR TITLE
Update Linux packaging

### DIFF
--- a/packaging/Linux/README.md
+++ b/packaging/Linux/README.md
@@ -2,9 +2,10 @@
 
 these are preliminary and just here to let people play with `solo5-spt`, the seccomp-enabled backend for [Solo5](https://github.com/Solo5/solo5) on Linux.
 
-1) You need to build the `vmm` tooling in this repository
-2) You need to build a `spt`-compatible binary to deploy.
+1) You need to build the `albatross` tooling in this repository
+2) To run unikernels, you need to build and install solo5-elftool and at least one of the tenders: solo5-hvt and solo5-spt. They can be installed somewhere in PATH or in /var/lib/albatross/.
+2) You need to build a binary with one of the tenders (solo5-hvt, solo5-spt) to deploy.
 3) See [`install.sh`](./install.sh) for commands required to deploy it.
 4) `sudo journalctl -fu albatross'*'.service`
 5) ideally, once the services are up and running, you would be able to issue this command to deploy a unikernel:
-   `sudo vmmc_local.native -t spt-amd64 --compression0 helloworld /path/to/hello_world.spt`
+   `sudo albatross-client-local helloworld /path/to/hello_world.spt`

--- a/packaging/Linux/albatross_log.service
+++ b/packaging/Linux/albatross_log.service
@@ -9,8 +9,9 @@ Requires=albatross_console.service
 [Service]
 Type=simple
 User=albatross
+AssertPathExists=/var/lib/albatross/albatross.log
 ExecStart=/usr/local/sbin/albatross-log --logfile="/var/lib/albatross/albatross.log" --tmpdir="%t/albatross/" -vv
-#RuntimeDirectory=albatross albatross/util
+RuntimeDirectory=albatross albatross/util
 #RuntimeDirectoryPreserve=yes # avoid albatross.log being cleaned up
 PIDFile=%t/albatross/log.pid
 RestrictAddressFamilies=AF_UNIX

--- a/packaging/Linux/install.sh
+++ b/packaging/Linux/install.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
+ALBATROSS_USER=albatross
+
 sudo mkdir -m 0700 -p /var/lib/albatross/block
+sudo install -o "$ALBATROSS_USER" -- /dev/null /var/lib/albatross/albatross.log
 
 sudo cp ../../_build/install/default/bin/* /usr/local/sbin/
 sudo cp ./albatross_*.service  /etc/systemd/system/


### PR DESCRIPTION
This change updates the README and fixes some bugs.

I'm not happy with the systemd scripts:
* `albatross_log` doesn't create the log file if it's missing
* If `albatross_log` immediately crashes its dependencies (`albatross_daemon`) is still started, and then it crashes as well due to not being able to connect to the logger socket.