### PR TITLE
Ergonomics

### DIFF
--- a/src/vmm_commands.ml
+++ b/src/vmm_commands.ml
@@ -141,12 +141,17 @@ type success = [
 let pp_block ppf (id, size, active) =
   Fmt.pf ppf "block %a size %d MB active %B" Name.pp id size active
 
+let my_fmt_list empty pp_elt ppf xs =
+  match xs with
+  | [] -> Fmt.string ppf empty
+  | _ -> Fmt.(list ~sep:(unit "@.") pp_elt ppf xs)
+
 let pp_success ppf = function
   | `Empty -> Fmt.string ppf "success"
   | `String data -> Fmt.pf ppf "success: %s" data
-  | `Policies ps -> Fmt.(list ~sep:(unit "@.") (pair ~sep:(unit ": ") Name.pp Policy.pp)) ppf ps
-  | `Unikernels vms -> Fmt.(list ~sep:(unit "@.") (pair ~sep:(unit ": ") Name.pp Unikernel.pp_config)) ppf vms
-  | `Block_devices blocks -> Fmt.(list ~sep:(unit "@.") pp_block) ppf blocks
+  | `Policies ps -> my_fmt_list "no policies" Fmt.(pair ~sep:(unit ": ") Name.pp Policy.pp) ppf ps
+  | `Unikernels vms -> my_fmt_list "no unikernels" Fmt.(pair ~sep:(unit ": ") Name.pp Unikernel.pp_config) ppf vms
+  | `Block_devices blocks -> my_fmt_list "no block devices" pp_block ppf blocks
 
 type res = [
   | `Command of t

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -215,7 +215,7 @@ let handle_policy_cmd t id = function
     match policies with
     | [] ->
       Logs.debug (fun m -> m "policies: couldn't find %a" Name.pp id) ;
-      Ok (t, `End (`Success (`String "no policies found")))
+      Ok (t, `End (`Success (`Policies policies)))
     | _ ->
       Ok (t, `End (`Success (`Policies policies)))
 
@@ -232,7 +232,7 @@ let handle_unikernel_cmd t id = function
     begin match vms with
       | [] ->
         Logs.debug (fun m -> m "info: couldn't find %a" Name.pp id) ;
-        Ok (t, `End (`Success (`String "no unikernels found")))
+        Ok (t, `End (`Success (`Unikernels vms)))
       | _ ->
         Ok (t, `End (`Success (`Unikernels vms)))
     end
@@ -307,7 +307,7 @@ let handle_block_cmd t id = function
     match blocks with
     | [] ->
       Logs.debug (fun m -> m "block: couldn't find %a" Name.pp id) ;
-      Ok (t, `End (`Success (`String "no block devices found")))
+      Ok (t, `End (`Success (`Block_devices blocks)))
     | _ ->
       Ok (t, `End (`Success (`Block_devices blocks)))
 

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -212,12 +212,7 @@ let handle_policy_cmd t id = function
         (fun prefix policy policies-> (prefix, policy) :: policies)
         []
     in
-    match policies with
-    | [] ->
-      Logs.debug (fun m -> m "policies: couldn't find %a" Name.pp id) ;
-      Ok (t, `End (`Success (`Policies policies)))
-    | _ ->
-      Ok (t, `End (`Success (`Policies policies)))
+    Ok (t, `End (`Success (`Policies policies)))
 
 let handle_unikernel_cmd t id = function
   | `Unikernel_info ->
@@ -229,13 +224,7 @@ let handle_unikernel_cmd t id = function
            (id, cfg) :: vms)
         []
     in
-    begin match vms with
-      | [] ->
-        Logs.debug (fun m -> m "info: couldn't find %a" Name.pp id) ;
-        Ok (t, `End (`Success (`Unikernels vms)))
-      | _ ->
-        Ok (t, `End (`Success (`Unikernels vms)))
-    end
+    Ok (t, `End (`Success (`Unikernels vms)))
   | `Unikernel_get ->
     Logs.debug (fun m -> m "get %a" Name.pp id) ;
     begin match Vmm_trie.find id t.resources.Vmm_resources.unikernels with
@@ -304,12 +293,7 @@ let handle_block_cmd t id = function
         (fun prefix (size, active) blocks -> (prefix, size, active) :: blocks)
         []
     in
-    match blocks with
-    | [] ->
-      Logs.debug (fun m -> m "block: couldn't find %a" Name.pp id) ;
-      Ok (t, `End (`Success (`Block_devices blocks)))
-    | _ ->
-      Ok (t, `End (`Success (`Block_devices blocks)))
+    Ok (t, `End (`Success (`Block_devices blocks)))
 
 let handle_command t (header, payload) =
   let msg_to_err = function

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -215,7 +215,7 @@ let handle_policy_cmd t id = function
     match policies with
     | [] ->
       Logs.debug (fun m -> m "policies: couldn't find %a" Name.pp id) ;
-      Error (`Msg "policy: not found")
+      Ok (t, `End (`Success (`String "no policies found")))
     | _ ->
       Ok (t, `End (`Success (`Policies policies)))
 
@@ -232,7 +232,7 @@ let handle_unikernel_cmd t id = function
     begin match vms with
       | [] ->
         Logs.debug (fun m -> m "info: couldn't find %a" Name.pp id) ;
-        Error (`Msg "info: no unikernel found")
+        Ok (t, `End (`Success (`String "no unikernels found")))
       | _ ->
         Ok (t, `End (`Success (`Unikernels vms)))
     end
@@ -307,7 +307,7 @@ let handle_block_cmd t id = function
     match blocks with
     | [] ->
       Logs.debug (fun m -> m "block: couldn't find %a" Name.pp id) ;
-      Error (`Msg "block: not found")
+      Ok (t, `End (`Success (`String "no block devices found")))
     | _ ->
       Ok (t, `End (`Success (`Block_devices blocks)))
 


### PR DESCRIPTION
The commands `block`, `info`, and `policy` currently return an error in the case that there are no block devices, unikernels or policies respectively. At the client this results in a dangerous-looking `[WARNING]` when those commands are run on a fresh install.

This change makes the daemon return success with an empty list instead of an error. Instead, pretty printing is modified to make a note of the list being empty.

This PR contains two commits. The previous would make the daemon return a string with the message. I think it's cleaner if it's up to the client to handle empty lists. I can squash the commits into one if preferred.