### PR TITLE
Be able to start and monitor BHyve virtual machines

### DIFF
--- a/client/albatross_client.ml
+++ b/client/albatross_client.ml
@@ -181,11 +181,11 @@ let http_get_binary ~happy_eyeballs host job build =
 
 let prepare_update ~happy_eyeballs level host dryrun = function
   | Ok (_hdr, `Success (`Unikernel_info
-      [ _name, Vmm_core.Unikernel.{ digest ; bridges ; block_devices ; argv ; startup ; cpuid ; memory ; fail_behaviour ; typ = `Solo5 as typ ; _ } ]))
+      [ _name, Vmm_core.Unikernel.{ digest ; bridges ; block_devices ; argv ; startup ; cpuid ; memory ; fail_behaviour ; typ = `Solo5 as typ ; cpus ; linux_boot_partition ; _ } ]))
   | Ok (_hdr, `Success (`Old_unikernel_info3
-      [ _name, Vmm_core.Unikernel.{ digest ; bridges ; block_devices ; argv ; startup ; cpuid ; memory ; fail_behaviour ; typ = `Solo5 as typ ; _ } ]))
+      [ _name, Vmm_core.Unikernel.{ digest ; bridges ; block_devices ; argv ; startup ; cpuid ; memory ; fail_behaviour ; typ = `Solo5 as typ ; cpus ; linux_boot_partition ; _ } ]))
   | Ok (_hdr, `Success (`Old_unikernel_info4
-      [ _name, Vmm_core.Unikernel.{ digest ; bridges ; block_devices ; argv ; startup ; cpuid ; memory ; fail_behaviour ; typ = `Solo5 as typ ; _ } ])) ->
+      [ _name, Vmm_core.Unikernel.{ digest ; bridges ; block_devices ; argv ; startup ; cpuid ; memory ; fail_behaviour ; typ = `Solo5 as typ ; cpus ; linux_boot_partition ; _ } ])) ->
     begin
       let hash = Ohex.encode digest in
       can_update ~happy_eyeballs host hash >>= function
@@ -229,7 +229,7 @@ let prepare_update ~happy_eyeballs level host dryrun = function
                 | 0 -> false, unikernel
                 | _ -> true, Vmm_compress.compress ~level unikernel
               in
-              let config = { Vmm_core.Unikernel.typ ; compressed ; image ; fail_behaviour ; startup ; add_name = true; cpuid; memory ; block_devices ; bridges ; argv } in
+              let config = { Vmm_core.Unikernel.typ ; compressed ; image ; fail_behaviour ; startup ; add_name = true; cpuid; memory ; block_devices ; bridges ; argv ; cpus ; linux_boot_partition } in
               Lwt.return (Ok (`Unikernel_force_create config))
     end
   | Ok w ->
@@ -238,7 +238,7 @@ let prepare_update ~happy_eyeballs level host dryrun = function
     Lwt.return (Error Communication_failed)
   | Error _ -> Lwt.return (Error Communication_failed)
 
-let create_unikernel force image startup no_add_name cpuid memory argv block_devices bridges compression restart_on_fail exit_codes =
+let create_unikernel force image startup no_add_name cpuid memory argv block_devices bridges compression restart_on_fail exit_codes cpus linux_boot_partition =
   let ( let* ) = Result.bind in
   let* () =
     if Vmm_core.String_set.(cardinal (of_list (List.map (fun (n, _, _) -> n) bridges))) = List.length bridges then
@@ -265,7 +265,7 @@ let create_unikernel force image startup no_add_name cpuid memory argv block_dev
     let exits = match exit_codes with [] -> None | xs -> Some (Vmm_core.IS.of_list xs) in
     if restart_on_fail then `Restart exits else `Quit
   in
-  let config = { Vmm_core.Unikernel.typ = `Solo5 ; compressed ; image ; fail_behaviour ; startup ; add_name = not no_add_name ; cpuid ; memory ; block_devices ; bridges ; argv } in
+  let config = { Vmm_core.Unikernel.typ = `Solo5 ; compressed ; image ; fail_behaviour ; startup ; add_name = not no_add_name ; cpuid ; memory ; block_devices ; bridges ; argv ; cpus ; linux_boot_partition } in
   if force then Ok (`Unikernel_force_create config) else Ok (`Unikernel_create config)
 
 let policy unikernels memory cpus block bridgesl =
@@ -786,12 +786,12 @@ let get () compression name dst =
 let destroy () = jump (`Unikernel_cmd `Unikernel_destroy)
 
 let create () force image startup no_add_name cpuid memory argv block network compression restart_on_fail exit_code
-  name d cert key ca key_type tmpdir =
-  match create_unikernel force image startup no_add_name cpuid memory argv block network (compress_default compression d) restart_on_fail exit_code with
+  cpus linux_boot_partition name d cert key ca key_type tmpdir =
+  match create_unikernel force image startup no_add_name cpuid memory argv block network (compress_default compression d) restart_on_fail exit_code cpus linux_boot_partition with
   | Ok cmd -> jump (`Unikernel_cmd cmd) name d cert key ca key_type tmpdir
   | Error _ as e -> e
 
-let restart () replace startup no_add_name cpuid memory argv block_devices bridges restart_on_fail exit_codes name d cert key ca key_type tmpdir =
+let restart () replace startup no_add_name cpuid memory argv block_devices bridges restart_on_fail exit_codes cpus linux_boot_partition name d cert key ca key_type tmpdir =
   let ( let* ) = Result.bind in
   let* args =
     if replace then
@@ -812,7 +812,7 @@ let restart () replace startup no_add_name cpuid memory argv block_devices bridg
         if restart_on_fail then `Restart exits else `Quit
       and argv = match argv with [] -> None | xs -> Some xs
       in
-      Ok (Some { Vmm_core.Unikernel.fail_behaviour ; startup ; add_name = not no_add_name ; cpuid ; memory ; block_devices ; bridges ; argv })
+      Ok (Some { Vmm_core.Unikernel.fail_behaviour ; startup ; add_name = not no_add_name ; cpuid ; memory ; block_devices ; bridges ; argv ; cpus ; linux_boot_partition })
     else
       Ok None
   in
@@ -1189,6 +1189,14 @@ let cpu =
   let doc = "CPUid to use." in
   Arg.(value & opt int 0 & info [ "cpu" ] ~doc)
 
+let number_cpus =
+  let doc = "How many CPUs to use." in
+  Arg.(value & opt int 1 & info [ "cpus" ] ~doc)
+
+let linux_boot_partition =
+  let doc = "Boot partition when booting a Linux system." in
+  Arg.(value & opt (some string) None & info [ "linux-boot" ] ~doc)
+
 let unikernel_mem =
   let doc = "Memory to assign (in MB)." in
   Arg.(value & opt int 32 & info [ "mem" ] ~doc)
@@ -1422,7 +1430,7 @@ let restart_cmd =
      `P "Restarts a unikernel."]
   in
   let term =
-    Term.(term_result (const restart $ (Albatross_cli.setup_log (const false)) $ replace_args $ startup $ no_add_name $ cpu $ unikernel_mem $ args $ block $ net $ restart_on_fail $ exit_code $ unikernel_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+    Term.(term_result (const restart $ (Albatross_cli.setup_log (const false)) $ replace_args $ startup $ no_add_name $ cpu $ unikernel_mem $ args $ block $ net $ restart_on_fail $ exit_code $ number_cpus $ linux_boot_partition $ unikernel_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
   and info = Cmd.info "restart" ~doc ~man ~exits
   in
   Cmd.v info term
@@ -1494,7 +1502,7 @@ let create_cmd =
      `P "Creates a unikernel."]
   in
   let term =
-    Term.(term_result (const create $ (Albatross_cli.setup_log (const false)) $ force $ image $ startup $ no_add_name $ cpu $ unikernel_mem $ args $ block $ net $ compress_level $ restart_on_fail $ exit_code $ unikernel_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+    Term.(term_result (const create $ (Albatross_cli.setup_log (const false)) $ force $ image $ startup $ no_add_name $ cpu $ unikernel_mem $ args $ block $ net $ compress_level $ restart_on_fail $ exit_code $ number_cpus $ linux_boot_partition $ unikernel_name $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
   and info = Cmd.info "create" ~doc ~man ~exits
   in
   Cmd.v info term

--- a/client/albatross_client.ml
+++ b/client/albatross_client.ml
@@ -1174,7 +1174,7 @@ let dryrun =
 
 let cpus =
   let doc = "CPUids to allow for this policy (argument may be repeated)." in
-  Arg.(value & opt_all int [] & info [ "cpu" ] ~doc)
+  Arg.(value & opt_all int [ 0 ] & info [ "cpu" ] ~doc)
 
 let unikernels =
   let doc = "Number of unikernels to allow running at the same time." in

--- a/daemon/albatrossd.ml
+++ b/daemon/albatrossd.ml
@@ -225,6 +225,7 @@ let jump _ systemd influx tmpdir dbdir no_drop dev_zvol =
   Sys.(set_signal sigpipe Signal_ignore);
   Albatross_cli.set_tmpdir tmpdir;
   Albatross_cli.set_dbdir dbdir;
+  Random.self_init ();
   Vmm_unix.drop_path := not no_drop;
   state := Vmm_vmmd.allow_dev_zvol !state dev_zvol;
   state := Vmm_vmmd.init_block_devices !state;

--- a/daemon/albatrossd.ml
+++ b/daemon/albatrossd.ml
@@ -221,11 +221,12 @@ let write_reply name fd txt (hdr, cmd) =
 
 let m = conn_metrics "unix"
 
-let jump _ systemd influx tmpdir dbdir no_drop =
+let jump _ systemd influx tmpdir dbdir no_drop dev_zvol =
   Sys.(set_signal sigpipe Signal_ignore);
   Albatross_cli.set_tmpdir tmpdir;
   Albatross_cli.set_dbdir dbdir;
   Vmm_unix.drop_path := not no_drop;
+  state := Vmm_vmmd.allow_dev_zvol !state dev_zvol;
   state := Vmm_vmmd.init_block_devices !state;
   (match Vmm_unix.check_commands () with
    | Error `Msg m -> invalid_arg m
@@ -332,6 +333,15 @@ let no_drop_path =
   let doc = "Do not drop unikernel path for --name (use --name=path:hello instead of --name=hello)" in
   Arg.(value & flag & info [ "no-drop-path" ] ~doc)
 
+let path_c =
+  Arg.conv
+    (Name.Path.of_string,
+     fun ppf p -> Name.pp ppf (Name.make_of_path p))
+
+let allow_dev_zvol =
+  let doc = "Allow /dev/zvol access to a certain arc" in
+  Arg.(value & opt (some path_c) None & info [ "allow-zvol-for" ] ~doc)
+
 let cmd =
   let doc = "Albatross daemon" in
   let man = [
@@ -353,7 +363,7 @@ let cmd =
       creation and attaching tap devices to bridges."
   ] in
   let term =
-    Term.(const jump $ (Albatross_cli.setup_log Albatrossd_utils.syslog) $ Albatrossd_utils.systemd_socket_activation $ Albatrossd_utils.influx $ Albatross_cli.tmpdir $ Albatross_cli.dbdir $ no_drop_path)
+    Term.(const jump $ (Albatross_cli.setup_log Albatrossd_utils.syslog) $ Albatrossd_utils.systemd_socket_activation $ Albatrossd_utils.influx $ Albatross_cli.tmpdir $ Albatross_cli.dbdir $ no_drop_path $ allow_dev_zvol)
   and info = Cmd.info "albatrossd" ~version:Albatross_cli.version ~doc ~man
   in
   Cmd.v info term

--- a/src/vmm_asn.ml
+++ b/src/vmm_asn.ml
@@ -361,7 +361,7 @@ let v0_unikernel_config =
     and add_name = true
     and cpuids = IS.singleton cpuid
     in
-    { typ ; compressed ; image ; fail_behaviour ; startup ; add_name ; cpuids ; memory ; block_devices ; bridges ; argv ; cpus = 1 ; linux_boot_partition = None }
+    { typ ; compressed ; image ; fail_behaviour ; startup ; add_name ; cpuids ; memory ; block_devices ; bridges ; argv ; numcpus = 1 ; linux_boot_partition = None }
   and g _unikernel = failwith "cannot encode v0 unikernel configs"
   in
   Asn.S.map f g @@
@@ -384,7 +384,7 @@ let v1_unikernel_config =
     and add_name = true
     and cpuids = IS.singleton cpuid
     in
-    { typ ; compressed ; image ; fail_behaviour ; startup ; add_name ; cpuids ; memory ; block_devices ; bridges ; argv ; cpus = 1 ; linux_boot_partition = None }
+    { typ ; compressed ; image ; fail_behaviour ; startup ; add_name ; cpuids ; memory ; block_devices ; bridges ; argv ; numcpus = 1 ; linux_boot_partition = None }
   and g _unikernel = failwith "cannot encode v1 unikernel configs"
   in
   Asn.S.(map f g @@ sequence @@
@@ -407,7 +407,7 @@ let v2_unikernel_config =
     and add_name = true
     and cpuids = IS.singleton cpuid
     in
-    { typ ; compressed ; image ; fail_behaviour ; startup ; add_name ; cpuids ; memory ; block_devices ; bridges ; argv ; cpus = 1 ; linux_boot_partition = None }
+    { typ ; compressed ; image ; fail_behaviour ; startup ; add_name ; cpuids ; memory ; block_devices ; bridges ; argv ; numcpus = 1 ; linux_boot_partition = None }
   and g (unikernel : config) =
     let bridges =
       match unikernel.bridges with
@@ -448,7 +448,7 @@ let v3_unikernel_config =
     and add_name = true
     and cpuids = IS.singleton cpuid
     in
-    { typ ; compressed ; image ; fail_behaviour ; startup ; add_name ; cpuids ; memory ; block_devices ; bridges ; argv ; cpus = 1 ; linux_boot_partition = None }
+    { typ ; compressed ; image ; fail_behaviour ; startup ; add_name ; cpuids ; memory ; block_devices ; bridges ; argv ; numcpus = 1 ; linux_boot_partition = None }
   and g (unikernel : config) =
     let bridges = match unikernel.bridges with [] -> None | xs -> Some xs
     and blocks = match unikernel.block_devices with [] -> None | xs -> Some xs
@@ -486,11 +486,11 @@ let v4_unikernel_config =
   let f (typ, (compressed, (image, (startup, (add_name, (fail_behaviour, (cpuid, (memory, (blocks, (bridges, argv)))))))))) =
     let bridges = match bridges with None -> [] | Some xs -> xs
     and block_devices = match blocks with None -> [] | Some xs -> xs
-    and cpus = 1
+    and numcpus = 1
     and cpuids = IS.singleton cpuid
     and linux_boot_partition = None
     in
-    { typ ; compressed ; image ; fail_behaviour ; startup ; add_name ; cpuids ; memory ; block_devices ; bridges ; argv ; cpus ; linux_boot_partition }
+    { typ ; compressed ; image ; fail_behaviour ; startup ; add_name ; cpuids ; memory ; block_devices ; bridges ; argv ; numcpus ; linux_boot_partition }
   and g (unikernel : config) =
     let bridges = match unikernel.bridges with [] -> None | xs -> Some xs
     and blocks = match unikernel.block_devices with [] -> None | xs -> Some xs
@@ -527,19 +527,19 @@ let v4_unikernel_config =
 
 let unikernel_config =
   let open Unikernel in
-  let f (typ, (compressed, (image, (startup, (add_name, (fail_behaviour, (cpuids, (memory, (blocks, (bridges, (argv, (cpus, linux_boot_partition)))))))))))) =
+  let f (typ, (compressed, (image, (startup, (add_name, (fail_behaviour, (cpuids, (memory, (blocks, (bridges, (argv, (numcpus, linux_boot_partition)))))))))))) =
     let bridges = match bridges with None -> [] | Some xs -> xs
     and block_devices = match blocks with None -> [] | Some xs -> xs
     and cpuids = IS.of_list cpuids
-    and cpus = Option.value ~default:1 cpus
+    and numcpus = Option.value ~default:1 numcpus
     in
-    { typ ; compressed ; image ; fail_behaviour ; startup ; add_name ; cpuids ; memory ; block_devices ; bridges ; argv ; cpus ; linux_boot_partition }
+    { typ ; compressed ; image ; fail_behaviour ; startup ; add_name ; cpuids ; memory ; block_devices ; bridges ; argv ; numcpus ; linux_boot_partition }
   and g (unikernel : config) =
     let bridges = match unikernel.bridges with [] -> None | xs -> Some xs
     and blocks = match unikernel.block_devices with [] -> None | xs -> Some xs
     and cpuids = IS.elements unikernel.cpuids
     in
-    (unikernel.typ, (unikernel.compressed, (unikernel.image, (unikernel.startup, (unikernel.add_name, (unikernel.fail_behaviour, (cpuids, (unikernel.memory, (blocks, (bridges, (unikernel.argv, (Some unikernel.cpus, unikernel.linux_boot_partition))))))))))))
+    (unikernel.typ, (unikernel.compressed, (unikernel.image, (unikernel.startup, (unikernel.add_name, (unikernel.fail_behaviour, (cpuids, (unikernel.memory, (blocks, (bridges, (unikernel.argv, (Some unikernel.numcpus, unikernel.linux_boot_partition))))))))))))
   in
   Asn.S.(map f g @@ sequence @@
            (required ~label:"typ" typ)
@@ -568,19 +568,19 @@ let unikernel_config =
 
 let unikernel_arguments =
   let open Unikernel in
-  let f (fail_behaviour, (startup, (add_name, (cpuids, (memory, (blocks, (bridges, (argv, (cpus, linux_boot_partition))))))))) =
+  let f (fail_behaviour, (startup, (add_name, (cpuids, (memory, (blocks, (bridges, (argv, (numcpus, linux_boot_partition))))))))) =
     let bridges = match bridges with None -> [] | Some xs -> xs
     and block_devices = match blocks with None -> [] | Some xs -> xs
-    and cpus = Option.value ~default:1 cpus
+    and numcpus = Option.value ~default:1 numcpus
     and cpuids = IS.of_list cpuids
     in
-    { fail_behaviour; startup; add_name; cpuids; memory; block_devices; bridges; argv; cpus; linux_boot_partition }
+    { fail_behaviour; startup; add_name; cpuids; memory; block_devices; bridges; argv; numcpus; linux_boot_partition }
   and g (unikernel : arguments) =
     let bridges = match unikernel.bridges with [] -> None | xs -> Some xs
     and blocks = match unikernel.block_devices with [] -> None | xs -> Some xs
     and cpuids = IS.elements unikernel.cpuids
     in
-    (unikernel.fail_behaviour, (unikernel.startup, (unikernel.add_name, (cpuids, (unikernel.memory, (blocks, (bridges, (unikernel.argv, (Some unikernel.cpus, unikernel.linux_boot_partition)))))))))
+    (unikernel.fail_behaviour, (unikernel.startup, (unikernel.add_name, (cpuids, (unikernel.memory, (blocks, (bridges, (unikernel.argv, (Some unikernel.numcpus, unikernel.linux_boot_partition)))))))))
   in
   Asn.S.(map f g @@ sequence @@
            (required ~label:"fail-behaviour" fail_behaviour)
@@ -609,11 +609,11 @@ let unikernel_arguments_v1 =
   let f (fail_behaviour, (startup, (add_name, (cpuid, (memory, (blocks, (bridges, argv))))))) =
     let bridges = match bridges with None -> [] | Some xs -> xs
     and block_devices = match blocks with None -> [] | Some xs -> xs
-    and cpus = 1
+    and numcpus = 1
     and cpuids = IS.singleton cpuid
     and linux_boot_partition = None
     in
-    { fail_behaviour; startup; add_name; cpuids; memory; block_devices; bridges; argv; cpus; linux_boot_partition }
+    { fail_behaviour; startup; add_name; cpuids; memory; block_devices; bridges; argv; numcpus; linux_boot_partition }
   and g (unikernel : arguments) =
     let bridges = match unikernel.bridges with [] -> None | xs -> Some xs
     and blocks = match unikernel.block_devices with [] -> None | xs -> Some xs
@@ -653,10 +653,10 @@ let unikernel_arguments_v0 =
     and startup = None
     and add_name = true
     and cpuids = IS.singleton cpuid
-    and cpus = 1
+    and numcpus = 1
     and linux_boot_partition = None
     in
-    { fail_behaviour ; startup ; add_name ; cpuids ; memory ; block_devices ; bridges ; argv ; cpus ; linux_boot_partition }
+    { fail_behaviour ; startup ; add_name ; cpuids ; memory ; block_devices ; bridges ; argv ; numcpus ; linux_boot_partition }
   and g (unikernel : arguments) =
     let bridges = match unikernel.bridges with [] -> None | xs -> Some xs
     and blocks = match unikernel.block_devices with [] -> None | xs -> Some xs
@@ -878,7 +878,7 @@ let old_unikernel_info3 =
     and startup = None
     and cpuids = IS.singleton cpuid
     in
-    { typ ; fail_behaviour ; startup ; cpuids ; memory ; block_devices ; bridges ; argv ; digest ; started ; cpus = 1 ; linux_boot_partition = None }
+    { typ ; fail_behaviour ; startup ; cpuids ; memory ; block_devices ; bridges ; argv ; digest ; started ; numcpus = 1 ; linux_boot_partition = None }
   and g (unikernel : info) =
     let bridges = match unikernel.bridges with
       | [] -> None
@@ -932,7 +932,7 @@ let old_unikernel_info4 =
     and startup = None
     and cpuids = IS.singleton cpuid
     in
-    { typ ; fail_behaviour ; startup ; cpuids ; memory ; block_devices ; bridges ; argv ; digest ; started ; cpus = 1 ; linux_boot_partition = None }
+    { typ ; fail_behaviour ; startup ; cpuids ; memory ; block_devices ; bridges ; argv ; digest ; started ; numcpus = 1 ; linux_boot_partition = None }
   and g (unikernel : info) =
     let bridges = match unikernel.bridges with
       | [] -> None
@@ -984,11 +984,11 @@ let old_unikernel_info5 =
           { unikernel_device ; host_device ; sector_size ; size })
         xs
     and started = Option.value ~default:Ptime.epoch started
-    and cpus = 1
+    and numcpus = 1
     and cpuids = IS.singleton cpuid
     and linux_boot_partition = None
     in
-    { typ ; fail_behaviour ; startup ; cpuids ; memory ; block_devices ; bridges ; argv ; digest ; started ; cpus ; linux_boot_partition }
+    { typ ; fail_behaviour ; startup ; cpuids ; memory ; block_devices ; bridges ; argv ; digest ; started ; numcpus ; linux_boot_partition }
   and g (unikernel : info) =
     let bridges = match unikernel.bridges with
       | [] -> None
@@ -1031,7 +1031,7 @@ let old_unikernel_info5 =
 
 let unikernel_info =
   let open Unikernel in
-  let f (typ, (startup, (fail_behaviour, (cpuids, (memory, (digest, (blocks, (bridges, (argv, (started, (cpus, linux_boot_partition))))))))))) =
+  let f (typ, (startup, (fail_behaviour, (cpuids, (memory, (digest, (blocks, (bridges, (argv, (started, (numcpus, linux_boot_partition))))))))))) =
     let bridges = match bridges with None -> [] | Some xs ->
       List.map (fun (unikernel_device, host_device, mac) ->
           { unikernel_device ; host_device ; mac })
@@ -1041,10 +1041,10 @@ let unikernel_info =
           { unikernel_device ; host_device ; sector_size ; size })
         xs
     and started = Option.value ~default:Ptime.epoch started
-    and cpus = Option.value ~default:1 cpus
+    and numcpus = Option.value ~default:1 numcpus
     and cpuids = IS.of_list cpuids
     in
-    { typ ; fail_behaviour ; startup ; cpuids ; memory ; block_devices ; bridges ; argv ; digest ; started ; cpus ; linux_boot_partition }
+    { typ ; fail_behaviour ; startup ; cpuids ; memory ; block_devices ; bridges ; argv ; digest ; started ; numcpus ; linux_boot_partition }
   and g (unikernel : info) =
     let bridges = match unikernel.bridges with
       | [] -> None
@@ -1056,7 +1056,7 @@ let unikernel_info =
           unikernel_device, host_device, sector_size, size) xs)
     and cpuids = IS.elements unikernel.cpuids
     in
-    (unikernel.typ, (unikernel.startup, (unikernel.fail_behaviour, (cpuids, (unikernel.memory, (unikernel.digest, (blocks, (bridges, (unikernel.argv, (Some unikernel.started, (Some unikernel.cpus, unikernel.linux_boot_partition)))))))))))
+    (unikernel.typ, (unikernel.startup, (unikernel.fail_behaviour, (cpuids, (unikernel.memory, (unikernel.digest, (blocks, (bridges, (unikernel.argv, (Some unikernel.started, (Some unikernel.numcpus, unikernel.linux_boot_partition)))))))))))
   in
   Asn.S.(map f g @@ sequence @@
            (required ~label:"typ" typ)

--- a/src/vmm_commands.ml
+++ b/src/vmm_commands.ml
@@ -60,6 +60,7 @@ type unikernel_cmd = [
   | `Unikernel_get of int
   | `Old_unikernel_info3
   | `Old_unikernel_info4
+  | `Old_unikernel_info5
 ]
 
 let pp_unikernel_cmd ~verbose ppf = function
@@ -80,6 +81,7 @@ let pp_unikernel_cmd ~verbose ppf = function
   | `Unikernel_get level -> Fmt.pf ppf "unikernel get compress level %d" level
   | `Old_unikernel_info3 -> Fmt.string ppf "old unikernel info3"
   | `Old_unikernel_info4 -> Fmt.string ppf "old unikernel info4"
+  | `Old_unikernel_info5 -> Fmt.string ppf "old unikernel info5"
 
 type policy_cmd = [
   | `Policy_info
@@ -160,6 +162,7 @@ type success = [
   | `Empty
   | `String of string
   | `Policies of (Name.t * Policy.t) list
+  | `Old_unikernel_info5 of (Name.t * Unikernel.info) list
   | `Old_unikernel_info4 of (Name.t * Unikernel.info) list
   | `Old_unikernel_info3 of (Name.t * Unikernel.info) list
   | `Unikernel_image of bool * string
@@ -183,7 +186,7 @@ let pp_success ~verbose ppf = function
   | `String data -> Fmt.pf ppf "success: %s" data
   | `Policies ps ->
     my_fmt_list "no policies" Fmt.(pair ~sep:(any ": ") Name.pp Policy.pp) ppf ps
-  | `Unikernel_info infos | `Old_unikernel_info3 infos | `Old_unikernel_info4 infos ->
+  | `Unikernel_info infos | `Old_unikernel_info3 infos | `Old_unikernel_info4 infos | `Old_unikernel_info5 infos ->
     my_fmt_list "no unikernels"
       Fmt.(pair ~sep:(any ": ") Name.pp
              (if verbose then Unikernel.pp_info_with_argv else Unikernel.pp_info))

--- a/src/vmm_commands.mli
+++ b/src/vmm_commands.mli
@@ -39,6 +39,7 @@ type unikernel_cmd = [
   | `Unikernel_get of int
   | `Old_unikernel_info3
   | `Old_unikernel_info4
+  | `Old_unikernel_info5
 ]
 
 type policy_cmd = [
@@ -90,6 +91,7 @@ type success = [
   | `Policies of (Name.t * Policy.t) list
   | `Old_unikernel_info3 of (Name.t * Unikernel.info) list
   | `Old_unikernel_info4 of (Name.t * Unikernel.info) list
+  | `Old_unikernel_info5 of (Name.t * Unikernel.info) list
   | `Unikernel_info of (Name.t * Unikernel.info) list
   | `Unikernel_image of bool * string
   | `Block_devices of (Name.t * int * bool) list

--- a/src/vmm_core.ml
+++ b/src/vmm_core.ml
@@ -403,13 +403,17 @@ module Unikernel = struct
   }
 
   let pp ppf unikernel =
-    let hex_digest = Ohex.encode unikernel.digest in
-    Fmt.pf ppf "pid %d@ taps %a (block %a) cmdline %a digest %s"
+    Fmt.pf ppf "pid %d@ taps %a (block %a) cmdline %a %s "
       unikernel.pid
       Fmt.(list ~sep:(any ", ") (pair ~sep:(any ": ") string Macaddr.pp)) unikernel.taps
       Fmt.(list ~sep:(any ", ") pp_block) unikernel.config.block_devices
-      Fmt.(array ~sep:(any " ") string) unikernel.cmd
-      hex_digest
+      Fmt.(array ~sep:(any " ") string) unikernel.cmd;
+    match unikernel.config.typ with
+    | `Solo5 ->
+      Fmt.pf ppf "digest %s"
+        (Ohex.encode unikernel.digest)
+    | `Bhyve ->
+      Fmt.pf ppf "bhyve-vmname %s" unikernel.digest
 
   type block_info = {
     unikernel_device : string ;

--- a/src/vmm_core.ml
+++ b/src/vmm_core.ml
@@ -268,9 +268,9 @@ module Policy = struct
       Error (`Msg (Fmt.str "policy above allows %d MB memory, which is fewer than %d MB"
                      super.memory sub.memory))
     else if not (IS.subset sub.cpuids super.cpuids) then
-      Error (`Msg (Fmt.str "policy above allows CPUids %a, which is not a superset of %a"
-                     Fmt.(list ~sep:(any ", ") int) (IS.elements super.cpuids)
-                     Fmt.(list ~sep:(any ", ") int) (IS.elements sub.cpuids)))
+      let diff = IS.diff sub.cpuids super.cpuids in
+      Error (`Msg (Fmt.str "policy above does not allow CPUids %a"
+                     Fmt.(list ~sep:(any ", ") int) (IS.elements diff)))
     else if not (String_set.subset sub.bridges super.bridges) then
       Error (`Msg (Fmt.str "policy above allows bridge(s) %a, which is not a superset of %a"
                      Fmt.(list ~sep:(any ", ") string) (String_set.elements super.bridges)
@@ -323,9 +323,9 @@ module Unikernel = struct
   let fine_with_policy (p : Policy.t) (c : config) =
     let bridge_allowed set s = String_set.mem s set in
     if not (IS.subset c.cpuids p.cpuids) then
-      Error (`Msg (Fmt.str "CPUid of unikernel (%a) not allowed by policy (%a)"
-                     Fmt.(list ~sep:(any ", ") int) (IS.elements c.cpuids)
-                     Fmt.(list ~sep:(any ", ") int) (IS.elements p.cpuids)))
+      let diff = IS.diff c.cpuids p.cpuids in
+      Error (`Msg (Fmt.str "the CPUids %a requested by the unikernel are not allowed by policy"
+                     Fmt.(list ~sep:(any ", ") int) (IS.elements diff)))
     else if c.memory > p.memory then
       Error (`Msg (Fmt.str "%u MB memory assigned to unikernel exceeds policy (%uMB)"
                      c.memory p.memory))

--- a/src/vmm_core.ml
+++ b/src/vmm_core.ml
@@ -235,7 +235,7 @@ module Policy = struct
     let bridges =
       if String_set.is_empty res.bridges then "" else ", bridges: "
     in
-    Fmt.pf ppf "policy: %d unikernels %a cpus %d MB memory %a block%s%a"
+    Fmt.pf ppf "policy: %d unikernels %a CPUids %u MB memory %a block%s%a"
       res.unikernels pp_is res.cpuids res.memory
       Fmt.(option ~none:(any "no") (int ++ any " MB")) res.block
       bridges
@@ -311,7 +311,7 @@ module Unikernel = struct
     block_devices : (string * string option * int option) list ;
     bridges : (string * string option * Macaddr.t option) list ;
     argv : string list option ;
-    cpus : int ; (* for bhyve *)
+    numcpus : int ; (* for bhyve *)
     linux_boot_partition : string option ; (* for bhyve, esp. linux *)
   }
 
@@ -346,7 +346,7 @@ module Unikernel = struct
       Fmt.(option ((any "@") ++ Macaddr.pp)) mac
 
   let pp_config ppf (unikernel : config) =
-    Fmt.pf ppf "typ %a@ compression %B image %d bytes@ fail behaviour %a@ startup at %a@ add_name %B@ cpus %a@ %d MB memory@ block devices %a@ bridge %a@ cpus %u@ linux_boot %a"
+    Fmt.pf ppf "typ %a@ compression %B image %d bytes@ fail behaviour %a@ startup at %a@ add_name %B@ CPUids %a@ %d MB memory@ block devices %a@ bridge %a@ #cpus %u@ linux_boot %a"
       pp_typ unikernel.typ
       unikernel.compressed
       (String.length unikernel.image)
@@ -357,7 +357,7 @@ module Unikernel = struct
       unikernel.memory
       Fmt.(list ~sep:(any ", ") pp_block) unikernel.block_devices
       Fmt.(list ~sep:(any ", ") pp_bridge) unikernel.bridges
-      unikernel.cpus
+      unikernel.numcpus
       Fmt.(option ~none:(any "not specified") string) unikernel.linux_boot_partition
 
   let pp_config_with_argv ppf (unikernel : config) =
@@ -376,12 +376,12 @@ module Unikernel = struct
     block_devices : (string * string option * int option) list ;
     bridges : (string * string option * Macaddr.t option) list ;
     argv : string list option ;
-    cpus : int ; (* for bhyve *)
+    numcpus : int ; (* for bhyve *)
     linux_boot_partition : string option ; (* for bhyve, esp. linux *)
   }
 
   let pp_arguments ppf (unikernel : arguments) =
-    Fmt.pf ppf "fail behaviour %a@ startup at %a@ add_name %B@ cpus %a@ %d MB memory@ block devices %a@ bridge %a@ cpus %u@ linux_boot_partition %a"
+    Fmt.pf ppf "fail behaviour %a@ startup at %a@ add_name %B@ CPUids %a@ %d MB memory@ block devices %a@ bridge %a@ #cpus %u@ linux_boot_partition %a"
       pp_fail_behaviour unikernel.fail_behaviour
       Fmt.(option ~none:(any "not specified") int) unikernel.startup
       unikernel.add_name
@@ -389,7 +389,7 @@ module Unikernel = struct
       unikernel.memory
       Fmt.(list ~sep:(any ", ") pp_block) unikernel.block_devices
       Fmt.(list ~sep:(any ", ") pp_bridge) unikernel.bridges
-      unikernel.cpus
+      unikernel.numcpus
       Fmt.(option ~none:(any "not specified") string) unikernel.linux_boot_partition
 
   let pp_arguments_with_argv ppf (unikernel : arguments) =
@@ -452,7 +452,7 @@ module Unikernel = struct
     argv : string list option ;
     digest : string ;
     started : Ptime.t ;
-    cpus : int ; (* for bhyve *)
+    numcpus : int ; (* for bhyve *)
     linux_boot_partition : string option ; (* for bhyve, esp. linux *)
   }
 
@@ -475,10 +475,10 @@ module Unikernel = struct
     { typ = cfg.typ ; fail_behaviour = cfg.fail_behaviour ; startup = cfg.startup ;
       cpuids = cfg.cpuids ; memory = cfg.memory ; block_devices ;
       bridges ; argv = cfg.argv ; digest = t.digest ; started = t.started ;
-      cpus = cfg.cpus ; linux_boot_partition = cfg.linux_boot_partition }
+      numcpus = cfg.numcpus ; linux_boot_partition = cfg.linux_boot_partition }
 
   let pp_info ppf (info : info) =
-    Fmt.pf ppf "typ %a@ started %a@ fail behaviour %a@ startup at %a@ cpus %a@ %u MB memory@ block devices %a@ bridge %a@ %a@ cpus %u@ linux_boot_partition %a"
+    Fmt.pf ppf "typ %a@ started %a@ fail behaviour %a@ startup at %a@ CPUids %a@ %u MB memory@ block devices %a@ bridge %a@ %a@ #cpus %u@ linux_boot_partition %a"
       pp_typ info.typ
       (Ptime.pp_rfc3339 ()) info.started
       pp_fail_behaviour info.fail_behaviour
@@ -488,7 +488,7 @@ module Unikernel = struct
       Fmt.(list ~sep:(any ", ") pp_block_info) info.block_devices
       Fmt.(list ~sep:(any ", ") pp_net_info) info.bridges
       (pp_digest info.typ) info.digest
-      info.cpus
+      info.numcpus
       Fmt.(option ~none:(any "not specified") string) info.linux_boot_partition
 
   let pp_info_with_argv ppf (info : info) =

--- a/src/vmm_core.mli
+++ b/src/vmm_core.mli
@@ -112,7 +112,7 @@ module Policy : sig
 end
 
 module Unikernel : sig
-  type typ = [ `Solo5 ]
+  type typ = [ `Solo5 | `BHyve ]
   val pp_typ : typ Fmt.t
 
   type fail_behaviour = [ `Quit | `Restart of IS.t option ]
@@ -129,6 +129,8 @@ module Unikernel : sig
     block_devices : (string * string option * int option) list ;
     bridges : (string * string option * Macaddr.t option) list ;
     argv : string list option ;
+    cpus : int ;
+    linux_boot_partition : string option ;
   }
 
   val bridges : config -> string list
@@ -150,6 +152,8 @@ module Unikernel : sig
     block_devices : (string * string option * int option) list ;
     bridges : (string * string option * Macaddr.t option) list ;
     argv : string list option ;
+    cpus : int ;
+    linux_boot_partition : string option ;
   }
 
   val pp_arguments : arguments Fmt.t
@@ -191,6 +195,8 @@ module Unikernel : sig
     argv : string list option ;
     digest : string ;
     started : Ptime.t ;
+    cpus : int ;
+    linux_boot_partition : string option ;
   }
 
   val info : (string -> int option) -> t -> info

--- a/src/vmm_core.mli
+++ b/src/vmm_core.mli
@@ -129,7 +129,7 @@ module Unikernel : sig
     block_devices : (string * string option * int option) list ;
     bridges : (string * string option * Macaddr.t option) list ;
     argv : string list option ;
-    cpus : int ;
+    numcpus : int ;
     linux_boot_partition : string option ;
   }
 
@@ -152,7 +152,7 @@ module Unikernel : sig
     block_devices : (string * string option * int option) list ;
     bridges : (string * string option * Macaddr.t option) list ;
     argv : string list option ;
-    cpus : int ;
+    numcpus : int ;
     linux_boot_partition : string option ;
   }
 
@@ -195,7 +195,7 @@ module Unikernel : sig
     argv : string list option ;
     digest : string ;
     started : Ptime.t ;
-    cpus : int ;
+    numcpus : int ;
     linux_boot_partition : string option ;
   }
 

--- a/src/vmm_core.mli
+++ b/src/vmm_core.mli
@@ -124,7 +124,7 @@ module Unikernel : sig
     fail_behaviour : fail_behaviour;
     startup : int option ;
     add_name : bool ;
-    cpuid : int ;
+    cpuids : IS.t ;
     memory : int ;
     block_devices : (string * string option * int option) list ;
     bridges : (string * string option * Macaddr.t option) list ;
@@ -147,7 +147,7 @@ module Unikernel : sig
     fail_behaviour : fail_behaviour;
     startup : int option;
     add_name : bool;
-    cpuid : int ;
+    cpuids : IS.t ;
     memory : int ;
     block_devices : (string * string option * int option) list ;
     bridges : (string * string option * Macaddr.t option) list ;
@@ -188,7 +188,7 @@ module Unikernel : sig
     typ : typ ;
     fail_behaviour : fail_behaviour;
     startup : int option ;
-    cpuid : int ;
+    cpuids : IS.t ;
     memory : int ;
     block_devices : block_info list ;
     bridges : net_info list ;

--- a/src/vmm_resources.ml
+++ b/src/vmm_resources.ml
@@ -220,7 +220,7 @@ let unikernels t name =
 let insert_unikernel t name unikernel =
   let unikernels, old = Vmm_trie.insert name unikernel t.unikernels in
   (match old with None -> () | Some _ -> invalid_arg ("unikernel " ^ Name.to_string name ^ " already exists in trie")) ;
-  let* block_devices = use_blocks t.block_devices name unikernel true in
+  let* block_devices = use_blocks ?dev_zvol:t.dev_zvol t.block_devices name unikernel true in
   let t' = { t with unikernels ; block_devices } in
   report_unikernels t' name;
   Ok t'

--- a/src/vmm_resources.ml
+++ b/src/vmm_resources.ml
@@ -168,9 +168,9 @@ let check_policy (p : Policy.t) (running_unikernels, used_memory) (unikernel : U
                    "maximum allowed memory (%d, used %d) would be exceeded (requesting %d)"
                    p.Policy.memory used_memory unikernel.Unikernel.memory))
   else if not (IS.subset unikernel.Unikernel.cpuids p.Policy.cpuids) then
-    Error (`Msg (Fmt.str "CPUids %a is not allowed by policy (%a)"
-                   Fmt.(list ~sep:(any ", ") int) (IS.elements unikernel.cpuids)
-                   Fmt.(list ~sep:(any ", ") int) (IS.elements p.cpuids)))
+    let diff = IS.diff unikernel.cpuids p.cpuids in
+    Error (`Msg (Fmt.str "CPUids %a are not allowed by policy"
+                   Fmt.(list ~sep:(any ", ") int) (IS.elements diff)))
   else
     match List.partition (bridge_allowed p.Policy.bridges) (Unikernel.bridges unikernel) with
     | _, [] -> Ok ()
@@ -294,9 +294,9 @@ let check_unikernels t path p =
   in
   let policy_block = match p.Policy.block with None -> 0 | Some x -> x in
   if not (IS.subset cpuids p.Policy.cpuids) then
-    Error (`Msg (Fmt.str "policy allows CPUids %a, which is not a superset of %a"
-                   Fmt.(list ~sep:(any ", ") int) (IS.elements p.Policy.cpuids)
-                   Fmt.(list ~sep:(any ", ") int) (IS.elements cpuids)))
+    let diff = IS.diff cpuids p.cpuids in
+    Error (`Msg (Fmt.str "policy does not allow CPUids %a"
+                   Fmt.(list ~sep:(any ", ") int) (IS.elements diff)))
   else if not (String_set.subset bridges p.Policy.bridges) then
     Error (`Msg (Fmt.str "policy allows bridges %a, which is not a superset of %a"
                    Fmt.(list ~sep:(any ", ") string) (String_set.elements p.Policy.bridges)

--- a/src/vmm_resources.mli
+++ b/src/vmm_resources.mli
@@ -18,11 +18,12 @@ type t = private {
   policies : Policy.t Vmm_trie.t ;
   block_devices : (int * bool) Vmm_trie.t ;
   unikernels : Unikernel.t Vmm_trie.t ;
+  dev_zvol : Name.Path.t option ;
 }
 
 
 (** [empty] is the empty tree. *)
-val empty : t
+val empty : Name.Path.t option -> t
 
 (** [find_unikernel t name] is either [Some unikernel] or [None]. *)
 val find_unikernel : t -> Name.t -> Unikernel.t option

--- a/src/vmm_unix.ml
+++ b/src/vmm_unix.ml
@@ -435,8 +435,10 @@ let free_system_resources name taps =
       destroy_tap n)
     (Ok ()) taps
 
-let cpuset cpu =
-  let cpustring = string_of_int cpu in
+let cpuset cpus =
+  let cpustring =
+    String.concat "," (List.map string_of_int (IS.elements cpus))
+  in
   match Lazy.force uname with
   | FreeBSD -> Ok ([ "cpuset" ; "-l" ; cpustring ])
   | Linux -> Ok ([ "taskset" ; "-c" ; cpustring ])
@@ -510,7 +512,7 @@ let exec name (config : Unikernel.config) bridge_taps blocks digest =
         else
           argv
       in
-      let* cpuset = cpuset config.Unikernel.cpuid in
+      let* cpuset = cpuset config.Unikernel.cpuids in
       let* target, version =
         let* image =
           if config.Unikernel.compressed then

--- a/src/vmm_unix.ml
+++ b/src/vmm_unix.ml
@@ -90,12 +90,12 @@ let read_fd_for_file = fd_for_file Unix.[ O_RDONLY ]
 
 let write_fd_for_file = fd_for_file Unix.[ O_WRONLY ; O_APPEND ]
 
-let null = match read_fd_for_file (Fpath.v "/dev/null") with
+let _null = match read_fd_for_file (Fpath.v "/dev/null") with
   | Ok fd -> fd
   | Error _ -> invalid_arg "cannot read /dev/null"
 
 let rec create_process prog args stdout =
-  try Unix.create_process prog args null stdout stdout with
+  try Unix.create_process prog args stdout stdout stdout with
   | Unix.Unix_error (Unix.EINTR, _, _) ->
       create_process prog args stdout
 

--- a/src/vmm_unix.ml
+++ b/src/vmm_unix.ml
@@ -95,6 +95,9 @@ let _null = match read_fd_for_file (Fpath.v "/dev/null") with
   | Error _ -> invalid_arg "cannot read /dev/null"
 
 let rec create_process prog args stdout =
+  (* NOTE: we use [stdout] for stdin with the assumption that it's not open for
+     reading and the other end never writes. This is due to bhyve calling
+     mevent_add on the fd which makes /dev/null not work. *)
   try Unix.create_process prog args stdout stdout stdout with
   | Unix.Unix_error (Unix.EINTR, _, _) ->
       create_process prog args stdout

--- a/src/vmm_unix.ml
+++ b/src/vmm_unix.ml
@@ -463,7 +463,7 @@ let exec_bhyve _name (config : Unikernel.config) bridge_taps digest =
   Bos.Cmd.(v "bhyve" % "-A" % "-H" % "-P" % "-s0,hostbridge" % "-s1,lpc"
            %% of_list network %% of_list blocks
            % "-lcom1,stdio"
-           % ("-c" ^ string_of_int config.cpus)
+           % ("-c" ^ string_of_int config.numcpus)
            % ("-m" ^ string_of_int config.memory ^ "M") % digest)
 
 let exec name (config : Unikernel.config) bridge_taps blocks digest =

--- a/src/vmm_unix.ml
+++ b/src/vmm_unix.ml
@@ -302,7 +302,7 @@ let manifest_devices_match ~bridges ~block_devices image =
   in
   devices_match ~bridges ~block_devices mft
 
-let bridge_name (service, b, _mac) = match b with None -> service | Some b -> b
+let device_name (service, b, _mac) = match b with None -> service | Some b -> b
 
 let bridge_exists bridge_name =
   let cmd =
@@ -318,7 +318,7 @@ let bridges_exist bridges =
   List.fold_left
     (fun acc b ->
        let* () = acc in
-       bridge_exists (bridge_name b))
+       bridge_exists (device_name b))
     (Ok ()) bridges
 
 let prepare_bhyve name (unikernel : Unikernel.config) =
@@ -371,7 +371,7 @@ let prepare name (unikernel : Unikernel.config) =
       let* _ =
         List.fold_left (fun n ((name, _, _) as arg) ->
             let* n in
-            let bridge = bridge_name arg in
+            let bridge = device_name arg in
             if String.equal name (string_of_int n) then
               Ok (succ n)
             else
@@ -381,7 +381,7 @@ let prepare name (unikernel : Unikernel.config) =
       let* _ =
         List.fold_left (fun n ((name, _, _) as arg) ->
             let* n in
-            let block = bridge_name arg in
+            let block = device_name arg in
             if String.equal name (string_of_int n) then
               Ok (succ n)
             else
@@ -412,7 +412,7 @@ let prepare name (unikernel : Unikernel.config) =
   let* taps =
     List.fold_left (fun acc arg ->
         let* acc = acc in
-        let bridge = bridge_name arg in
+        let bridge = device_name arg in
         let* tap = create_tap bridge in
         let (service, _, mac) = arg in
         Ok ((service, tap, mac) :: acc))

--- a/src/vmm_unix.ml
+++ b/src/vmm_unix.ml
@@ -433,6 +433,10 @@ let unikernel_device unikernel =
   | FreeBSD -> Ok ("solo5-" ^ string_of_int unikernel.Unikernel.pid)
   | Linux -> Error (`Msg "don't know what you mean (trying to find unikernel device)")
 
+let destroy_bhyve name =
+  let cmd = Bos.Cmd.(v "bhyvectl" % "--destroy" % ("--vm=" ^ name)) in
+  Bos.OS.Cmd.(run_out ~err:err_null cmd |> out_null |> success)
+
 let free_system_resources name taps =
   (* same order as prepare! *)
   let* () = Bos.OS.File.delete (Name.image_file name) in

--- a/src/vmm_unix.ml
+++ b/src/vmm_unix.ml
@@ -86,13 +86,7 @@ let fd_for_file flag f =
   try Ok (openfile (Fpath.to_string f) (Unix.O_CLOEXEC :: flag) 0o644)
   with Unix.Unix_error (e, _, _) -> err_file f e
 
-let read_fd_for_file = fd_for_file Unix.[ O_RDONLY ]
-
 let write_fd_for_file = fd_for_file Unix.[ O_WRONLY ; O_APPEND ]
-
-let _null = match read_fd_for_file (Fpath.v "/dev/null") with
-  | Ok fd -> fd
-  | Error _ -> invalid_arg "cannot read /dev/null"
 
 let rec create_process prog args stdout =
   (* NOTE: we use [stdout] for stdin with the assumption that it's not open for

--- a/src/vmm_unix.ml
+++ b/src/vmm_unix.ml
@@ -329,7 +329,7 @@ let prepare_bhyve name (unikernel : Unikernel.config) =
   in
   match unikernel.Unikernel.linux_boot_partition with
   | None ->
-    let cmd = Bos.Cmd.(v "bhyveload" % ("-m" ^ string_of_int unikernel.memory ^ "m") % ("-d" ^  disk_name) % name) in
+    let cmd = Bos.Cmd.(v "timeout" % "1s" % "bhyveload" % ("-m" ^ string_of_int unikernel.memory ^ "m") % ("-d" ^  disk_name) % name) in
     Bos.OS.Cmd.(run_out ~err:err_null cmd |> out_null |> success)
   | Some boot_name ->
     Result.join
@@ -338,11 +338,9 @@ let prepare_bhyve name (unikernel : Unikernel.config) =
             output_string output v;
             close_out_noerr output;
             let cmd =
-              Bos.Cmd.(v "grub-bhyve" % ("-m" ^ Fpath.to_string file) % ("-rhd0," ^ boot_name) % ("-M" ^ string_of_int unikernel.memory) % name)
+              Bos.Cmd.(v "timeout" % "1s"% "grub-bhyve" % ("-m" ^ Fpath.to_string file) % ("-rhd0," ^ boot_name) % ("-M" ^ string_of_int unikernel.memory) % name)
             in
-            let cmd_string = Bos.Cmd.to_string cmd in
-            let res = Sys.command cmd_string in
-            if res = 0 then Ok () else Error (`Msg ("grub-bhyve returned " ^ string_of_int res)))
+            Bos.OS.Cmd.(run_out ~err:err_null cmd |> out_null |> success))
          ("(hd0) " ^ disk_name ^ "\n"))
 
 let prepare name (unikernel : Unikernel.config) =

--- a/src/vmm_unix.ml
+++ b/src/vmm_unix.ml
@@ -340,7 +340,9 @@ let prepare_bhyve name (unikernel : Unikernel.config) =
             let cmd =
               Bos.Cmd.(v "grub-bhyve" % ("-m" ^ Fpath.to_string file) % ("-rhd0," ^ boot_name) % ("-M" ^ string_of_int unikernel.memory) % name)
             in
-            Bos.OS.Cmd.(run_out ~err:err_null cmd |> out_null |> success))
+            let cmd_string = Bos.Cmd.to_string cmd in
+            let res = Sys.command cmd_string in
+            if res = 0 then Ok () else Error (`Msg ("grub-bhyve returned " ^ string_of_int res)))
          ("(hd0) " ^ disk_name ^ "\n"))
 
 let prepare name (unikernel : Unikernel.config) =

--- a/src/vmm_unix.mli
+++ b/src/vmm_unix.mli
@@ -22,6 +22,8 @@ val prepare : Name.t -> Unikernel.config ->
 val exec : Name.t -> Unikernel.config -> (string * string * Macaddr.t option) list ->
   (string * Name.t * int option) list -> string -> (Unikernel.t, [> `Msg of string ]) result
 
+val destroy_bhyve : string -> (unit, [> `Msg of string ]) result
+
 val free_system_resources : Name.t -> string list -> (unit, [> `Msg of string ]) result
 
 val destroy : Unikernel.t -> unit

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -248,13 +248,13 @@ let handle_create t name ~needs_dump unikernel_config =
       (cons_out, success, fail))
 
 let handle_shutdown t name unikernel r =
+  (match unikernel.Unikernel.config.typ with
+   | `BHyve -> Vmm_unix.destroy_bhyve unikernel.digest |> ignore
+   | `Solo5 -> ());
   (match Vmm_unix.free_system_resources name (List.map fst unikernel.Unikernel.taps) with
    | Ok () -> ()
    | Error (`Msg e) ->
      Logs.err (fun m -> m "%s while shutdown unikernel %a" e Unikernel.pp unikernel));
-  (match unikernel.config.typ with
-   | `BHyve -> Vmm_unix.destroy_bhyve unikernel.digest |> ignore
-   | `Solo5 -> ());
   Logs.info (fun m -> m "unikernel %a (PID %d) stopped with %a"
                 Name.pp name unikernel.Unikernel.pid pp_process_exit r);
   let t, stat_out = remove_stats t name in

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -232,6 +232,9 @@ let handle_create t name ~needs_dump unikernel_config =
     let t, stat_out = setup_stats t name unikernel in
     Ok (t, stat_out, `Success (`String "created unikernel"), name, unikernel)
   and fail () =
+    (match unikernel_config.typ with
+     | `BHyve -> Vmm_unix.destroy_bhyve digest |> ignore
+     | `Solo5 -> ());
     match Vmm_unix.free_system_resources name (List.map (fun (_,tap,_) -> tap) taps) with
     | Ok () -> `Failure "could not create unikernel: console failed"
     | Error (`Msg msg) ->
@@ -246,6 +249,9 @@ let handle_shutdown t name unikernel r =
    | Ok () -> ()
    | Error (`Msg e) ->
      Logs.err (fun m -> m "%s while shutdown unikernel %a" e Unikernel.pp unikernel));
+  (match unikernel.config.typ with
+   | `BHyve -> Vmm_unix.destroy_bhyve unikernel.digest |> ignore
+   | `Solo5 -> ());
   Logs.info (fun m -> m "unikernel %a (PID %d) stopped with %a"
                 Name.pp name unikernel.Unikernel.pid pp_process_exit r);
   let t, stat_out = remove_stats t name in

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -108,10 +108,13 @@ let killall t create =
 let empty = {
   console_counter = 1L ;
   stats_counter = 1L ;
-  resources = Vmm_resources.empty ;
+  resources = Vmm_resources.empty None ;
   waiters = String_map.empty ;
   restarting = String_set.empty ;
 }
+
+let allow_dev_zvol t dev_zvol =
+  { t with resources = Vmm_resources.empty dev_zvol }
 
 let init_block_devices t =
   match Vmm_unix.find_block_devices () with

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -327,6 +327,18 @@ let handle_unikernel_cmd t id =
           (Vmm_trie.find id t.resources.Vmm_resources.unikernels)
     in
     Ok (t, `End (`Success (`Old_unikernel_info4 infos)))
+  | `Old_unikernel_info5 ->
+    Logs.debug (fun m -> m "old info5 %a" Name.pp id) ;
+    let infos =
+      match Name.name id with
+      | None ->
+        Vmm_trie.fold (Name.path id) t.resources.Vmm_resources.unikernels
+          (fun id unikernel unikernels -> (id, Unikernel.info (block_size id) unikernel) :: unikernels) []
+      | Some _ ->
+        Option.fold ~none:[] ~some:(fun unikernel -> [ id, Unikernel.info (block_size id) unikernel ])
+          (Vmm_trie.find id t.resources.Vmm_resources.unikernels)
+    in
+    Ok (t, `End (`Success (`Old_unikernel_info5 infos)))
   | `Unikernel_info ->
     Logs.debug (fun m -> m "info %a" Name.pp id) ;
     let infos =
@@ -399,7 +411,7 @@ let handle_unikernel_cmd t id =
               fail_behaviour = a.fail_behaviour ;
               startup = a.startup ;
               add_name = a.add_name ;
-              cpuid = a.cpuid ;
+              cpuids = a.cpuids ;
               block_devices = a.block_devices ;
               bridges = a.bridges ;
               argv = a.argv }

--- a/src/vmm_vmmd.mli
+++ b/src/vmm_vmmd.mli
@@ -6,6 +6,8 @@ type 'a t
 
 val empty : 'a t
 
+val allow_dev_zvol : 'a t -> Name.Path.t option -> 'a t
+
 val init_block_devices : 'a t -> 'a t
 
 val waiter : 'a t -> Name.t -> 'a t * 'a option

--- a/test/albatross_client_gen.ml
+++ b/test/albatross_client_gen.ml
@@ -7,6 +7,7 @@ let u1 =
     block_devices = [ "block", None, None ; "secondblock", Some "second-data", None ] ;
     bridges = [ "service", None, None ; "other-net", Some "second-bridge", None ] ;
     argv = Some [ "-l *:debug" ] ;
+    cpus = 1 ; linux_boot_partition = None ;
   }
 
 let u2 =
@@ -16,6 +17,7 @@ let u2 =
     block_devices = [] ;
     bridges = [ "service", Some "bridge-interface", Some (Macaddr.of_string_exn "00:de:ad:be:ef:00") ] ;
     argv = None ;
+    cpus = 1 ; linux_boot_partition = None ;
   }
 
 let unikernels =

--- a/test/albatross_client_gen.ml
+++ b/test/albatross_client_gen.ml
@@ -3,7 +3,7 @@
 let u1 =
   Vmm_core.Unikernel.{
     typ = `Solo5 ; compressed = false ; image = "";
-    fail_behaviour = `Quit ; startup = None ; add_name = true ; cpuid = 0 ; memory = 1 ;
+    fail_behaviour = `Quit ; startup = None ; add_name = true ; cpuids = Vmm_core.IS.singleton 0 ; memory = 1 ;
     block_devices = [ "block", None, None ; "secondblock", Some "second-data", None ] ;
     bridges = [ "service", None, None ; "other-net", Some "second-bridge", None ] ;
     argv = Some [ "-l *:debug" ] ;
@@ -13,7 +13,7 @@ let u1 =
 let u2 =
   Vmm_core.Unikernel.{
     typ = `Solo5 ; compressed = false ; image = "";
-    fail_behaviour = `Quit ; startup = None ; add_name = true ; cpuid = 2 ; memory = 10 ;
+    fail_behaviour = `Quit ; startup = None ; add_name = true ; cpuids = Vmm_core.IS.singleton 2 ; memory = 10 ;
     block_devices = [] ;
     bridges = [ "service", Some "bridge-interface", Some (Macaddr.of_string_exn "00:de:ad:be:ef:00") ] ;
     argv = None ;

--- a/test/albatross_client_gen.ml
+++ b/test/albatross_client_gen.ml
@@ -7,7 +7,7 @@ let u1 =
     block_devices = [ "block", None, None ; "secondblock", Some "second-data", None ] ;
     bridges = [ "service", None, None ; "other-net", Some "second-bridge", None ] ;
     argv = Some [ "-l *:debug" ] ;
-    cpus = 1 ; linux_boot_partition = None ;
+    numcpus = 1 ; linux_boot_partition = None ;
   }
 
 let u2 =
@@ -17,7 +17,7 @@ let u2 =
     block_devices = [] ;
     bridges = [ "service", Some "bridge-interface", Some (Macaddr.of_string_exn "00:de:ad:be:ef:00") ] ;
     argv = None ;
-    cpus = 1 ; linux_boot_partition = None ;
+    numcpus = 1 ; linux_boot_partition = None ;
   }
 
 let unikernels =

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -290,7 +290,7 @@ let u =
     block_devices = [] ;
     bridges = [ "service", None, None ] ;
     argv = Some [ "-l *:debug" ] ;
-    cpus = 1 ; linux_boot_partition = None ;
+    numcpus = 1 ; linux_boot_partition = None ;
   }
 
 let ok_msg = Alcotest.(result unit msg)
@@ -703,7 +703,7 @@ let u1_3 =
     block_devices = [ "block", None, None ; "secondblock", Some "second-data", None ] ;
     bridges = [ "service", None, None ; "other-net", Some "second-bridge", None ] ;
     argv = Some [ "-l *:debug" ] ;
-    cpus = 1 ; linux_boot_partition = None ;
+    numcpus = 1 ; linux_boot_partition = None ;
   }
 
 let u2_3 =
@@ -713,7 +713,7 @@ let u2_3 =
     block_devices = [] ;
     bridges = [ "service", Some "bridge-interface", None ] ;
     argv = None ;
-    cpus = 1 ; linux_boot_partition = None ;
+    numcpus = 1 ; linux_boot_partition = None ;
   }
 
 let ins n u t =

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -261,7 +261,7 @@ let unikernel_config_eq =
      | `Restart None, `Restart None -> true
      | `Restart Some a, `Restart Some b -> IS.equal a b
      | _ -> false) &&
-    a.cpuid = b.cpuid && a.memory = b.memory &&
+    IS.equal a.cpuids b.cpuids && a.memory = b.memory &&
     eq_triple_list_opt_int a.block_devices b.block_devices &&
     eq_triple_list_opt_mac a.bridges b.bridges &&
     Option.equal (List.equal String.equal) a.argv b.argv
@@ -286,7 +286,7 @@ let test_resources =
 let u =
   Unikernel.{
     typ = `Solo5 ; compressed = false ; image = "" ;
-    fail_behaviour = `Quit ; startup = None ; add_name = true ; cpuid = 0 ; memory = 10 ;
+    fail_behaviour = `Quit ; startup = None ; add_name = true ; cpuids = IS.singleton 0 ; memory = 10 ;
     block_devices = [] ;
     bridges = [ "service", None, None ] ;
     argv = Some [ "-l *:debug" ] ;
@@ -322,7 +322,7 @@ let policy_is_respected_unikernel () =
     (Vmm_resources.check_unikernel r1 (n_o_s "alpha:bar") u);
   Alcotest.check ok_msg __LOC__ (Ok ())
     (Vmm_resources.check_unikernel r1 (n_o_s "alpha:bar") u);
-  let u' = { u with cpuid = 1 } in
+  let u' = { u with cpuids = IS.singleton 1 } in
   Alcotest.check ok_msg __LOC__ (Error (`Msg "cpuid not allowed"))
     (Vmm_resources.check_unikernel r1 (n_o_s "alpha:bar") u');
   let u' = { u with memory = 11 } in
@@ -699,7 +699,7 @@ let dec_b64_unik data =
 let u1_3 =
   Unikernel.{
     typ = `Solo5 ; compressed = false ; image = "" ;
-    fail_behaviour = `Quit ; startup = None ; add_name = true ; cpuid = 0 ; memory = 1 ;
+    fail_behaviour = `Quit ; startup = None ; add_name = true ; cpuids = IS.singleton 0 ; memory = 1 ;
     block_devices = [ "block", None, None ; "secondblock", Some "second-data", None ] ;
     bridges = [ "service", None, None ; "other-net", Some "second-bridge", None ] ;
     argv = Some [ "-l *:debug" ] ;
@@ -709,7 +709,7 @@ let u1_3 =
 let u2_3 =
   Unikernel.{
     typ = `Solo5 ; compressed = false ; image = "" ;
-    fail_behaviour = `Quit ; startup = None ; add_name = true ; cpuid = 2 ; memory = 10 ;
+    fail_behaviour = `Quit ; startup = None ; add_name = true ; cpuids = IS.singleton 2 ; memory = 10 ;
     block_devices = [] ;
     bridges = [ "service", Some "bridge-interface", None ] ;
     argv = None ;

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -290,20 +290,21 @@ let u =
     block_devices = [] ;
     bridges = [ "service", None, None ] ;
     argv = Some [ "-l *:debug" ] ;
+    cpus = 1 ; linux_boot_partition = None ;
   }
 
 let ok_msg = Alcotest.(result unit msg)
 
 let empty_resources () =
-  Alcotest.check test_resources __LOC__ Vmm_resources.empty Vmm_resources.empty;
+  Alcotest.check test_resources __LOC__ (Vmm_resources.empty None) (Vmm_resources.empty None);
   Alcotest.check ok_msg __LOC__ (Ok ())
-    Vmm_resources.(check_unikernel empty (n_o_s "foo") u);
+    Vmm_resources.(check_unikernel (empty None) (n_o_s "foo") u);
   Alcotest.check ok_msg __LOC__ (Ok ())
-    Vmm_resources.(check_unikernel empty (n_o_s "bar") u);
+    Vmm_resources.(check_unikernel (empty None) (n_o_s "bar") u);
   Alcotest.check ok_msg __LOC__ (Ok ())
-    Vmm_resources.(check_unikernel empty (n_o_s "foo:bar") u);
+    Vmm_resources.(check_unikernel (empty None) (n_o_s "foo:bar") u);
   Alcotest.check ok_msg __LOC__ (Ok ())
-    Vmm_resources.(check_block empty (n_o_s "foo:bar") 10)
+    Vmm_resources.(check_block (empty None) (n_o_s "foo:bar") 10)
 
 let p1 = Policy.{
     unikernels = 1 ;
@@ -314,7 +315,7 @@ let p1 = Policy.{
   }
 
 let r1 =
-  Result.get_ok (Vmm_resources.(insert_policy empty (p_o_s "alpha") p1))
+  Result.get_ok (Vmm_resources.(insert_policy (empty None) (p_o_s "alpha") p1))
 
 let policy_is_respected_unikernel () =
   Alcotest.check ok_msg __LOC__ (Ok ())
@@ -337,7 +338,7 @@ let policy_is_respected_block () =
   Alcotest.check ok_msg __LOC__ (Error (`Msg "block disallowed"))
     (Vmm_resources.check_block r1 (n_o_s "alpha:bar") 10);
   let p' = { p1 with block = None } in
-  let r = Result.get_ok (Vmm_resources.(insert_policy empty (p_o_s "alpha") p')) in
+  let r = Result.get_ok (Vmm_resources.(insert_policy (empty None) (p_o_s "alpha") p')) in
   Alcotest.check ok_msg __LOC__ (Error (`Msg "block disallowed"))
     (Vmm_resources.check_block r (n_o_s "alpha:bar") 5)
 
@@ -431,10 +432,10 @@ let policy_can_be_overwritten () =
   | Error _ -> Alcotest.fail "overwriting of policy should work"
 
 let resource_insert_block () =
-  (match Vmm_resources.(insert_block empty (n_o_s "foo") 10) with
+  (match Vmm_resources.(insert_block (empty None) (n_o_s "foo") 10) with
    | Ok _ -> ()
    | Error _ -> Alcotest.fail "expected insertion of block to succeed");
-  (match Vmm_resources.(insert_block empty (n_o_s "foo") 10) with
+  (match Vmm_resources.(insert_block (empty None) (n_o_s "foo") 10) with
    | Error _ -> Alcotest.fail "expected insertion of block to succeed"
    | Ok t ->
      match Vmm_resources.(insert_block t (n_o_s "foo") 10) with
@@ -446,12 +447,12 @@ let resource_insert_block () =
          match Vmm_resources.insert_block t (n_o_s "foo") 10 with
          | Error _ -> Alcotest.fail "expected insertion of block to succeed"
          | Ok _ -> ());
-  match Vmm_resources.(remove_block empty (n_o_s "foo")) with
+  match Vmm_resources.(remove_block (empty None) (n_o_s "foo")) with
   | Error _ -> ()
   | Ok _ -> Alcotest.fail "expected removal of non-existing block to fail"
 
 let resource_remove_policy () =
-  (match Vmm_resources.(remove_policy empty (p_o_s "foo")) with
+  (match Vmm_resources.(remove_policy (empty None) (p_o_s "foo")) with
    | Error _ -> ()
    | Ok _ -> Alcotest.fail "expected removal of non-existing policy to fail");
   (match Vmm_resources.remove_policy r1 (p_o_s "alpha") with
@@ -702,6 +703,7 @@ let u1_3 =
     block_devices = [ "block", None, None ; "secondblock", Some "second-data", None ] ;
     bridges = [ "service", None, None ; "other-net", Some "second-bridge", None ] ;
     argv = Some [ "-l *:debug" ] ;
+    cpus = 1 ; linux_boot_partition = None ;
   }
 
 let u2_3 =
@@ -711,6 +713,7 @@ let u2_3 =
     block_devices = [] ;
     bridges = [ "service", Some "bridge-interface", None ] ;
     argv = None ;
+    cpus = 1 ; linux_boot_partition = None ;
   }
 
 let ins n u t =


### PR DESCRIPTION
This is not very well tested yet. EDIT: but a basic FreeBSD VM is starting :) [and console output is visible]

- [x] Test with a Linux VM (using the grub-bhyve path)
- [x] Test with multiple network interfaces
- [x] What is not done is pinning to specific CPU(s). This requires some further change(s), since there's only a single "cpu", but a BHyve VM may use more CPUs.
- [x] Also, the resources/resource usage needs to be adjusted for these BHyve VMs. At the moment, we have a short exit for /dev/zvol -- not albatross_daemon has a command-line argument `--allow-zvol-for` - as a temporary workaround (until #219 is a thing)
- [x] Only some common and standard things are supported, namely there's no support for `-d` for grub-bhyve. 
- [x] The restart-on-failure as well needs to be rethought / revised. <- this is fine, if a reboot is issued, the exit code of bhyve is 0, which matches the restart-on-failure. Exit code 1 is for "halt"

Later a path on how to install a virtual machine given you have nothing -- usually done via a boot CD or memstick... this is not very well thought out yet (but if you have an image, just block_set it, and you're done :)