### PR TITLE
Also dump the state if we're coming out of a restart handler, and will not restart a unikernel

### DIFF
--- a/daemon/albatrossd.ml
+++ b/daemon/albatrossd.ml
@@ -48,7 +48,8 @@ let rec create stat_out cons_out data_out name ~needs_dump config =
                         create stat_out cons_out stub_data_out
                           name ~needs_dump:false unikernel.Unikernel.config
                       else
-                        Lwt.return_unit)));
+                        (Vmm_vmmd.dump_state !state;
+                         Lwt.return_unit))));
          stat_out "setting up stat" stat >|= fun () ->
          (Some unikernel, data)) >>= fun (started, data) ->
   (match started with


### PR DESCRIPTION
If we have a unikernel that exited on a non-restartable exit code, we should dump the state to not restart it upon next albatross start. Fixup for observed #249 fallout.