### PR TITLE
add commands for albatross logging service

### DIFF
--- a/client/albatross_client.ml
+++ b/client/albatross_client.ml
@@ -849,6 +849,9 @@ let console () since count =
 let inactive_consoles () path =
   jump (`Console_cmd `Console_list_inactive) (Vmm_core.Name.make_of_path path)
 
+let log_subscribe () path =
+  jump (`Log_cmd `Log_subscribe) (Vmm_core.Name.make_of_path path)
+
 let stats_add () vmmdev pid bridge_taps =
   let vmmdev = Option.value ~default:"" vmmdev in
   jump (`Stats_cmd (`Stats_add (vmmdev, pid, bridge_taps)))
@@ -1560,6 +1563,18 @@ let inactive_consoles_cmd =
   in
   Cmd.v info term
 
+let log_subscribe_cmd =
+  let doc = "Log events from albatross." in
+  let man =
+    [`S "DESCRIPTION";
+     `P "Shows log events from albatross."]
+  in
+  let term =
+    Term.(term_result (const log_subscribe $ (Albatross_cli.setup_log (const false)) $ opt_path $ dst $ ca_cert $ ca_key $ server_ca $ pub_key_type $ Albatross_cli.tmpdir))
+  and info = Cmd.info "log" ~doc ~man ~exits
+  in
+  Cmd.v info term
+
 let stats_subscribe_cmd =
   let doc = "Statistics of unikernel." in
   let man =
@@ -1787,7 +1802,7 @@ let cmds = [
   info_cmd ; get_cmd ; destroy_cmd ; create_cmd ; restart_cmd ;
   block_info_cmd ; block_create_cmd ; block_destroy_cmd ;
   block_set_cmd ; block_dump_cmd ;
-  console_cmd ; inactive_consoles_cmd ;
+  console_cmd ; inactive_consoles_cmd ; log_subscribe_cmd ;
   stats_subscribe_cmd ; stats_add_cmd ; stats_remove_cmd ;
   update_cmd ; inspect_dump_cmd ; extract_dump_cmd ; cert_cmd ;
   sign_cmd ; generate_cmd ; (* TODO revoke_cmd *)

--- a/daemon/albatrossd.ml
+++ b/daemon/albatrossd.ml
@@ -18,8 +18,7 @@ let create_lock = Lwt_mutex.create ()
    Vmm_vmmd.handle is getting called, and while communicating via
    console / stat socket communication. *)
 
-let send_log ev =
-  let name = Vmm_core.Logging.name ev in
+let send_log name ev =
   let fds = Vmm_trie.collect name !log_fds in
   Lwt_list.map_p (fun (name, (fd, version, sequence)) ->
       let header = Vmm_commands.header ~version ~sequence name in
@@ -86,9 +85,9 @@ let rec create stat_out cons_out data_out name ~needs_dump config =
    | None -> ()
    | Some unikernel ->
      Lwt.async (fun () ->
-         send_log (`Unikernel_started name) >>= fun () ->
+         send_log name `Unikernel_started >>= fun () ->
          Vmm_lwt.wait_and_clear unikernel.Unikernel.pid >>= fun r ->
-         send_log (`Unikernel_stopped (name, r)) >>= fun () ->
+         send_log name (`Unikernel_stopped r) >>= fun () ->
          Lwt_mutex.with_lock create_lock (fun () ->
              let state', stat' = Vmm_vmmd.handle_shutdown !state name unikernel r in
              state := state';

--- a/daemon/albatrossd.ml
+++ b/daemon/albatrossd.ml
@@ -8,12 +8,42 @@ let state = ref Vmm_vmmd.empty
 
 let stats_fd = ref None
 
+let (log_fds : (Lwt_unix.file_descr * Vmm_commands.version * int64) Vmm_trie.t ref) =
+  ref Vmm_trie.empty
+
 let stub_data_out _ = Lwt.return_unit
 
 let create_lock = Lwt_mutex.create ()
 (* the global lock held during execution of create -- and also while
    Vmm_vmmd.handle is getting called, and while communicating via
    console / stat socket communication. *)
+
+let send_log ev =
+  let name = Vmm_core.Logging.name ev in
+  let fds = Vmm_trie.collect name !log_fds in
+  Lwt_list.map_p (fun (name, (fd, version, sequence)) ->
+      let header = Vmm_commands.header ~version ~sequence name in
+      Vmm_lwt.write_wire fd (header, `Data (`Log_data ev)) >>= function
+      | Ok () -> Lwt.return (name, Some (Int64.succ sequence))
+      | Error _ ->
+        Logs.info (fun m -> m "log failed to write");
+        Vmm_lwt.safe_close fd >|= fun () ->
+        (name, None))
+    fds >|= fun to_change ->
+  let new_log_fds =
+    List.fold_left (fun fds (name, data) ->
+        match Vmm_trie.find name fds, data with
+        | None, Some _ ->
+          (* uh oh, how did we end up here? *)
+          Logs.warn (fun m -> m "log fd for %a no longer present" Name.pp name);
+          fds
+        | None, None -> fds
+        | Some _, None -> Vmm_trie.remove name fds
+        | Some (efd, ver, _), Some seq ->
+          fst (Vmm_trie.insert name (efd, ver, seq) fds))
+      !log_fds to_change
+  in
+  log_fds := new_log_fds
 
 let rec create stat_out cons_out data_out name ~needs_dump config =
   (match Vmm_vmmd.handle_create ~needs_dump !state name config with
@@ -56,7 +86,9 @@ let rec create stat_out cons_out data_out name ~needs_dump config =
    | None -> ()
    | Some unikernel ->
      Lwt.async (fun () ->
+         send_log (`Unikernel_started name) >>= fun () ->
          Vmm_lwt.wait_and_clear unikernel.Unikernel.pid >>= fun r ->
+         send_log (`Unikernel_stopped (name, r)) >>= fun () ->
          Lwt_mutex.with_lock create_lock (fun () ->
              let state', stat' = Vmm_vmmd.handle_shutdown !state name unikernel r in
              state := state';
@@ -184,6 +216,19 @@ let handle cons_out stat_out fd addr =
           stats_fd := Some fd;
           out wire >>= fun () ->
           Lwt_list.iter_s (stat_out "setting up stats") datas >|= fun () ->
+          Lwt_mutex.unlock create_lock;
+          `Retain
+        | `Add_log (id, version) ->
+          let new_log_fds, replaced =
+            Vmm_trie.insert id (fd, version, 0L) !log_fds
+          in
+          (match replaced with
+           | Some (fd, _, _) ->
+             Logs.info (fun m -> m "logs for %a has been replaced"
+                           Vmm_core.Name.pp id);
+             Vmm_lwt.safe_close fd
+           | None -> Lwt.return_unit) >|= fun () ->
+          log_fds := new_log_fds;
           Lwt_mutex.unlock create_lock;
           `Retain
   in

--- a/src/vmm_asn.ml
+++ b/src/vmm_asn.ml
@@ -847,19 +847,16 @@ let exit_c =
 
 let log_ev =
   let f = function
-    | `C1 name -> `Unikernel_started name
-    | `C2 (name, ex) -> `Unikernel_stopped (name, ex)
+    | `C1 () -> `Unikernel_started
+    | `C2 ex -> `Unikernel_stopped ex
   and g = function
-    | `Unikernel_started name -> `C1 name
-    | `Unikernel_stopped (name, ex) -> `C2 (name, ex)
+    | `Unikernel_started -> `C1 ()
+    | `Unikernel_stopped ex -> `C2 ex
   in
   Asn.S.map f g @@
   Asn.S.(choice2
-           (my_explicit 0 ~label:"unikernel-start" name)
-           (my_explicit 1 ~label:"unikernel-stop"
-              (sequence2
-                 (required ~label:"name" name)
-                 (required ~label:"exit" exit_c))))
+           (my_explicit 0 ~label:"unikernel-start" null)
+           (my_explicit 1 ~label:"unikernel-stop" exit_c))
 
 let data =
   let f = function

--- a/src/vmm_asn.ml
+++ b/src/vmm_asn.ml
@@ -736,7 +736,6 @@ let unikernel_cmd =
              (my_explicit 20 ~label:"create" unikernel_config)
              (my_explicit 21 ~label:"force-create" unikernel_config)))
 
-
 let policy_cmd =
   let f = function
     | `C1 () -> `Policy_info
@@ -793,42 +792,88 @@ let block_cmd =
              (my_explicit 6 ~label:"dump" int)
              (my_explicit 7 ~label:"set" bool)))
 
+let log_cmd =
+  let f = function
+    | `C1 () -> `Log_subscribe
+    | `C2 _ -> assert false
+  and g = function
+    | `Log_subscribe -> `C1 ()
+  in
+  Asn.S.map f g @@
+  Asn.S.(choice2
+           (my_explicit 0 ~label:"subscribe" null)
+           (my_explicit 1 ~label:"PLACEHOLDER" bool))
+
 let wire_command =
   let f = function
     | `C1 console -> `Console_cmd console
     | `C2 stats -> `Stats_cmd stats
-    | `C3 () -> Asn.S.parse_error "support for log dropped"
-    | `C4 unikernel -> `Unikernel_cmd unikernel
-    | `C5 policy -> `Policy_cmd policy
-    | `C6 block -> `Block_cmd block
+    | `C3 unikernel -> `Unikernel_cmd unikernel
+    | `C4 policy -> `Policy_cmd policy
+    | `C5 block -> `Block_cmd block
+    | `C6 log -> `Log_cmd log
   and g = function
     | `Console_cmd c -> `C1 c
     | `Stats_cmd c -> `C2 c
-    | `Unikernel_cmd c -> `C4 c
-    | `Policy_cmd c -> `C5 c
-    | `Block_cmd c -> `C6 c
+    | `Unikernel_cmd c -> `C3 c
+    | `Policy_cmd c -> `C4 c
+    | `Block_cmd c -> `C5 c
+    | `Log_cmd c -> `C6 c
   in
   Asn.S.map f g @@
   Asn.S.(choice6
            (my_explicit 0 ~label:"console" console_cmd)
            (my_explicit 1 ~label:"statistics" stats_cmd)
-           (my_explicit 2 ~label:"log" null)
            (my_explicit 3 ~label:"unikernel" unikernel_cmd)
            (my_explicit 4 ~label:"policy" policy_cmd)
-           (my_explicit 5 ~label:"block" block_cmd))
+           (my_explicit 5 ~label:"block" block_cmd)
+           (my_explicit 6 ~label:"log" log_cmd))
+
+let exit_c =
+  let f = function
+    | `C1 i -> `Exit i
+    | `C2 i -> `Signal i
+    | `C3 i -> `Stop i
+  and g = function
+    | `Exit i -> `C1 i
+    | `Signal i -> `C2 i
+    | `Stop i -> `C3 i
+  in
+  Asn.S.map f g @@
+  Asn.S.(choice3
+           (my_explicit 0 ~label:"exit" int)
+           (my_explicit 1 ~label:"signal" int)
+           (my_explicit 2 ~label:"stop" int))
+
+let log_ev =
+  let f = function
+    | `C1 name -> `Unikernel_started name
+    | `C2 (name, ex) -> `Unikernel_stopped (name, ex)
+  and g = function
+    | `Unikernel_started name -> `C1 name
+    | `Unikernel_stopped (name, ex) -> `C2 (name, ex)
+  in
+  Asn.S.map f g @@
+  Asn.S.(choice2
+           (my_explicit 0 ~label:"unikernel-start" name)
+           (my_explicit 1 ~label:"unikernel-stop"
+              (sequence2
+                 (required ~label:"name" name)
+                 (required ~label:"exit" exit_c))))
 
 let data =
   let f = function
     | `C1 (ru, ifs, vmm, mem) -> `Stats_data (ru, mem, vmm, ifs)
-    | `C2 () -> Asn.S.parse_error "support for log was dropped"
-    | `C3 (timestamp, data) -> `Console_data (timestamp, data)
-    | `C4 `C1 s -> `Block_data (Some s)
-    | `C4 `C2 () -> `Block_data None
+    | `C2 (timestamp, data) -> `Console_data (timestamp, data)
+    | `C3 `C1 s -> `Block_data (Some s)
+    | `C3 `C2 () -> `Block_data None
+    | `C4 e -> `Log_data e
   and g = function
-    | `Console_data (timestamp, data) -> `C3 (timestamp, data)
+    | `Console_data (timestamp, data) -> `C2 (timestamp, data)
     | `Stats_data (ru, mem, ifs, vmm) -> `C1 (ru, vmm, ifs, mem)
-    | `Block_data None -> `C4 (`C2 ())
-    | `Block_data Some s -> `C4 (`C1 s)
+    | `Block_data None -> `C3 (`C2 ())
+    | `Block_data Some s -> `C3 (`C1 s)
+    | `Log_data e -> `C4 e
   in
   Asn.S.map f g @@
   Asn.S.(choice4
@@ -841,15 +886,15 @@ let data =
                                     (required ~label:"key" utf8_string)
                                     (required ~label:"value" int64))))
                  (optional ~label:"kinfo-mem" @@ implicit 1 kinfo_mem)))
-           (my_explicit 2 ~label:"log" null)
-           (my_explicit 3 ~label:"console"
+           (my_explicit 2 ~label:"console"
               (sequence2
                  (required ~label:"timestamp" generalized_time)
                  (required ~label:"data" utf8_string)))
-           (my_explicit 4 ~label:"block"
+           (my_explicit 3 ~label:"block"
               (choice2
                  (my_explicit 0 ~label:"some data" octet_string)
-                 (my_explicit 1 ~label:"no data" null))))
+                 (my_explicit 1 ~label:"no data" null)))
+           (my_explicit 4 ~label:"log" log_ev))
 
 let old_unikernel_info4 =
   let open Unikernel in

--- a/src/vmm_commands.ml
+++ b/src/vmm_commands.ml
@@ -118,12 +118,20 @@ let pp_block_cmd ppf = function
   | `Block_add size -> Fmt.pf ppf "block add %d" size
   | `Block_set compressed -> Fmt.pf ppf "block set compressed %B" compressed
 
+type log_cmd = [
+  | `Log_subscribe
+]
+
+let pp_log_cmd ppf = function
+  | `Log_subscribe -> Fmt.string ppf "log subscribe"
+
 type t = [
     | `Console_cmd of console_cmd
     | `Stats_cmd of stats_cmd
     | `Unikernel_cmd of unikernel_cmd
     | `Policy_cmd of policy_cmd
     | `Block_cmd of block_cmd
+    | `Log_cmd of log_cmd
   ]
 
 let pp ~verbose ppf = function
@@ -132,11 +140,13 @@ let pp ~verbose ppf = function
   | `Unikernel_cmd v -> pp_unikernel_cmd ~verbose ppf v
   | `Policy_cmd p -> pp_policy_cmd ppf p
   | `Block_cmd b -> pp_block_cmd ppf b
+  | `Log_cmd l -> pp_log_cmd ppf l
 
 type data = [
   | `Console_data of Ptime.t * string
   | `Stats_data of Stats.t
   | `Block_data of string option
+  | `Log_data of Logging.t
 ]
 
 let pp_data ppf = function
@@ -150,6 +160,7 @@ let pp_data ppf = function
     Fmt.pf ppf "block data %a"
       Fmt.(option ~none:(any "eof") (int ++ any " bytes"))
       (Option.map String.length s)
+  | `Log_data e -> Fmt.pf ppf "log data %a" Logging.pp e
 
 type header = {
   version : version ;
@@ -228,3 +239,4 @@ let endpoint = function
   | `Stats_cmd _ -> `Stats, `Single
   | `Console_cmd `Console_list_inactive -> `Console, `Single
   | `Console_cmd _ -> `Console, `Read
+  | `Log_cmd _ -> `Vmmd, `Read

--- a/src/vmm_commands.mli
+++ b/src/vmm_commands.mli
@@ -58,12 +58,17 @@ type block_cmd = [
   | `Block_set of bool
 ]
 
+type log_cmd = [
+  | `Log_subscribe
+]
+
 type t = [
   | `Console_cmd of console_cmd
   | `Stats_cmd of stats_cmd
   | `Unikernel_cmd of unikernel_cmd
   | `Policy_cmd of policy_cmd
   | `Block_cmd of block_cmd
+  | `Log_cmd of log_cmd
 ]
 
 val pp : verbose:bool -> t Fmt.t
@@ -72,6 +77,7 @@ type data = [
   | `Console_data of Ptime.t * string
   | `Stats_data of Stats.t
   | `Block_data of string option
+  | `Log_data of Logging.t
 ]
 
 val pp_data : data Fmt.t

--- a/src/vmm_core.ml
+++ b/src/vmm_core.ml
@@ -662,16 +662,12 @@ opam exit codes:
 
 module Logging = struct
   type t = [
-    | `Unikernel_started of Name.t
-    | `Unikernel_stopped of Name.t * process_exit
+    | `Unikernel_started
+    | `Unikernel_stopped of process_exit
   ]
 
-  let name = function
-    | `Unikernel_started name -> name
-    | `Unikernel_stopped (name, _) -> name
-
   let pp ppf = function
-    | `Unikernel_started n -> Fmt.pf ppf "unikernel %a started" Name.pp n
-    | `Unikernel_stopped (n, e) ->
-      Fmt.pf ppf "unikernel %a stopped with %a" Name.pp n pp_process_exit e
+    | `Unikernel_started -> Fmt.pf ppf "unikernel started"
+    | `Unikernel_stopped e ->
+      Fmt.pf ppf "unikernel stopped with %a" pp_process_exit e
 end

--- a/src/vmm_core.ml
+++ b/src/vmm_core.ml
@@ -659,3 +659,19 @@ opam exit codes:
       Logs.info (fun m -> m "unikernel %a exited %d, not restarting %a"
                     Name.pp name i Unikernel.pp_fail_behaviour config.fail_behaviour);
       false
+
+module Logging = struct
+  type t = [
+    | `Unikernel_started of Name.t
+    | `Unikernel_stopped of Name.t * process_exit
+  ]
+
+  let name = function
+    | `Unikernel_started name -> name
+    | `Unikernel_stopped (name, _) -> name
+
+  let pp ppf = function
+    | `Unikernel_started n -> Fmt.pf ppf "unikernel %a started" Name.pp n
+    | `Unikernel_stopped (n, e) ->
+      Fmt.pf ppf "unikernel %a stopped with %a" Name.pp n pp_process_exit e
+end

--- a/src/vmm_core.mli
+++ b/src/vmm_core.mli
@@ -280,11 +280,9 @@ val should_restart : Unikernel.config -> Name.t -> process_exit -> bool
 
 module Logging : sig
   type t = [
-    | `Unikernel_started of Name.t
-    | `Unikernel_stopped of Name.t * process_exit
+    | `Unikernel_started
+    | `Unikernel_stopped of process_exit
   ]
-
-  val name : t -> Name.t
 
   val pp : t Fmt.t
 end

--- a/src/vmm_core.mli
+++ b/src/vmm_core.mli
@@ -277,3 +277,14 @@ type process_exit = [ `Exit of int | `Signal of int | `Stop of int ]
 val pp_process_exit : process_exit Fmt.t
 
 val should_restart : Unikernel.config -> Name.t -> process_exit -> bool
+
+module Logging : sig
+  type t = [
+    | `Unikernel_started of Name.t
+    | `Unikernel_stopped of Name.t * process_exit
+  ]
+
+  val name : t -> Name.t
+
+  val pp : t Fmt.t
+end

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -594,6 +594,9 @@ let handle_stats_initial t stats_counter =
   in
   Ok (t, `Replace_stats (`Success `Empty, data))
 
+let handle_log_cmd t id version = function
+  | `Log_subscribe -> Ok (t, `Add_log (id, version))
+
 let handle_command t (header, payload) =
   let msg_to_err = function
     | Ok x -> Ok x
@@ -601,6 +604,7 @@ let handle_command t (header, payload) =
       Logs.err (fun m -> m "error while processing command: %s" msg) ;
       Error (`Failure msg)
   and id = header.Vmm_commands.name
+  and version = header.version
   in
   msg_to_err (
     match payload with
@@ -609,6 +613,7 @@ let handle_command t (header, payload) =
     | `Command (`Block_cmd bc) -> handle_block_cmd t id bc
     | `Command (`Stats_cmd `Stats_initial) ->
       handle_stats_initial t header.Vmm_commands.sequence
+    | `Command (`Log_cmd l) -> handle_log_cmd t id version l
     | _ ->
       Logs.err (fun m -> m "ignoring %a"
                    (Vmm_commands.pp_wire ~verbose:false) (header, payload)) ;

--- a/src/vmm_vmmd.mli
+++ b/src/vmm_vmmd.mli
@@ -38,7 +38,8 @@ val handle_command : 'a t -> Vmm_commands.wire ->
    | `End of Vmm_commands.res
    | `Wait of Name.t * (process_exit -> Vmm_commands.res)
    | `Wait_and_create of Name.t * (Name.t * Unikernel.config)
-   | `Replace_stats of Vmm_commands.res * Vmm_commands.wire list ],
+   | `Replace_stats of Vmm_commands.res * Vmm_commands.wire list
+   | `Add_log of Name.t * Vmm_commands.version ],
    Vmm_commands.res) result
 
 val killall : 'a t -> (unit -> 'b * 'a) -> 'a t * 'b list


### PR DESCRIPTION
The log service (part of vmm_vmmd / albatrossd) acts as follows:
- every path can subscribe once (existing subscriber is kicked)
- whenever a unikernel (below that subscribed path) is started or stopped, the subscriber receives a log event

Client: add log subcommand

fixes #278 //cc @PizieDust please tell which events and which data carried in the events would be useful -- also whether the "one log sink per path" is fine (I guess similar to stats, there's only the need from mollymawk to subscribe once to the log).